### PR TITLE
Enable carbon-reduction targets and attained values

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,4 +27,5 @@ jobs:
         pip install -r src/requirements.txt
     - name: Run Tests
       run: |
-        python src/manage.py test
+        cd src
+        python manage.py test

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,5 +27,4 @@ jobs:
         pip install -r src/requirements.txt
     - name: Run Tests
       run: |
-        cd src
-        python manage.py test
+        python src/manage.py test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ timelog.csv
 **/.DS_Store
 
 \.vscode/
+
+*.env

--- a/src/_main_/settings.py
+++ b/src/_main_/settings.py
@@ -29,7 +29,7 @@ IS_PROD = False
 SECRET_KEY =  os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = [
     'localhost',

--- a/src/api/handlers/page_settings__home.py
+++ b/src/api/handlers/page_settings__home.py
@@ -129,7 +129,7 @@ class HomePageSettingsHandler(RouteHandler):
         'attained_number_of_actions': parse_int(args.pop('attained_number_of_actions', 0)),
         'target_number_of_actions': parse_int(args.pop('target_number_of_actions', 0)),
         'attained_number_of_households': parse_int(args.pop('attained_number_of_households', 0)),
-        'target_number_of_households': parse_int(args.pop('target_number_of_households', 0))
+        'target_number_of_households': parse_int(args.pop('target_number_of_households', 0)),
         'attained_carbon_footprint_reduction': parse_int(args.pop('attained_carbon_footprint_reduction', 0)),
         'target_carbon_footprint_reduction': parse_int(args.pop('target_carbon_footprint_reduction', 0))
       }

--- a/src/api/handlers/page_settings__home.py
+++ b/src/api/handlers/page_settings__home.py
@@ -117,7 +117,7 @@ class HomePageSettingsHandler(RouteHandler):
       #checks for length
       for t in args["featured_links"]:
         if len(t["description"]) >  40:
-          return MassenergizeResponse(error=f"Please description text for {t['title']} should be less than 40 characters")
+          return MassenergizeResponse(error=f"Description text for {t['title']} should be less than 40 characters")
 
       # events
       args['show_featured_events'] = parse_bool(args.pop('show_featured_events', True))
@@ -130,6 +130,8 @@ class HomePageSettingsHandler(RouteHandler):
         'target_number_of_actions': parse_int(args.pop('target_number_of_actions', 0)),
         'attained_number_of_households': parse_int(args.pop('attained_number_of_households', 0)),
         'target_number_of_households': parse_int(args.pop('target_number_of_households', 0))
+        'attained_carbon_footprint_reduction': parse_int(args.pop('attained_carbon_footprint_reduction', 0)),
+        'target_carbon_footprint_reduction': parse_int(args.pop('target_carbon_footprint_reduction', 0))
       }
 
       args.pop('organic_attained_number_of_households', None)

--- a/src/api/store/graph.py
+++ b/src/api/store/graph.py
@@ -94,7 +94,7 @@ class GraphStore:
 
     carbon_footprint_reduction = 0 if not community.goal or not community.goal.attained_carbon_footprint_reduction else community.goal.attained_carbon_footprint_reduction
     # loop over actions completed
-    while actionRel = done_actions.next():
+    for actionRel in done_actions:
       if actionRel.action and actionRel.action.calculator_action :
         carbon_footprint_reduction += actionRel.action.calculator_action.average_points
 
@@ -108,7 +108,7 @@ class GraphStore:
     done_actions = UserActionRel.objects.filter(status="DONE")
     actions_completed = done_actions.count()
     carbon_footprint_reduction = 0
-    while actionRel = done_actions.next():
+    for actionRel in done_actions:
       if actionRel.action and actionRel.action.calculator_action :
         carbon_footprint_reduction += actionRel.action.calculator_action.average_points 
 

--- a/src/api/store/page_settings__home.py
+++ b/src/api/store/page_settings__home.py
@@ -58,7 +58,6 @@ class HomePageSettingsStore:
           if attained_number_of_actions:
             community_goal.attained_number_of_actions = attained_number_of_actions
           
-
           target_number_of_actions = goal_updates.get('target_number_of_actions', None)
           if target_number_of_actions:
             community_goal.target_number_of_actions = target_number_of_actions
@@ -68,10 +67,19 @@ class HomePageSettingsStore:
           if attained_number_of_households:
             community_goal.attained_number_of_households = attained_number_of_households
           
-
           target_number_of_households = goal_updates.get('target_number_of_households', None)
-          if attained_number_of_actions:
+          if target_number_of_actions:
             community_goal.target_number_of_households = target_number_of_households
+
+
+          attained_carbon_footprint_reduction = goal_updates.get('attained_carbon_footprint_reduction', None)
+          if attained_carbon_footprint_reduction:
+            community_goal.attained_carbon_footprint_reduction = attained_carbon_footprint_reduction
+          
+          target_carbon_footprint_reduction = goal_updates.get('target_carbon_footprint_reduction', None)
+          if target_carbon_footprint_reduction:
+            community_goal.target_carbon_footprint_reduction = target_carbon_footprint_reduction
+
 
           community_goal.save()
       

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -39,7 +39,7 @@ class TeamStore:
       teams = Team.objects.filter(community=community)
       ans = []
       for team in teams:
-        res = {"members": 0, "households": 0, "actions": 0, "actions_completed": 0, "actions_todo": 0}
+        res = {"members": 0, "households": 0, "actions": 0, "actions_completed": 0, "actions_todo": 0, "carbon_footprint_reduction": 0}
         res["team"] = team.simple_json()
         # team.members deprecated
         # for m in team.members.all():
@@ -50,8 +50,12 @@ class TeamStore:
           res["households"] += user.real_estate_units.count()
           actions = user.useractionrel_set.all()
           res["actions"] += len(actions)
-          res["actions_completed"] += actions.filter(**{"status":"DONE"}).count()
+          done_actions = actions.filter(**{"status":"DONE"})
+          res["actions_completed"] += done_actions.count()
           res["actions_todo"] += actions.filter(**{"status":"TODO"}).count()
+          for done_action in done_actions:
+            if done_action.action and done_action.action.calculator_action:
+              res["carbon_footprint_reduction"] += done_action.action.calculator_action.average_points
 
         ans.append(res)
 

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -50,9 +50,9 @@ class TeamStore:
           res["households"] += user.real_estate_units.count()
           actions = user.useractionrel_set.all()
           res["actions"] += len(actions)
-          done_actions = actions.filter(**{"status":"DONE"})
+          done_actions = actions.filter(status="DONE")
           res["actions_completed"] += done_actions.count()
-          res["actions_todo"] += actions.filter(**{"status":"TODO"}).count()
+          res["actions_todo"] += actions.filter(status="TODO").count()
           for done_action in done_actions:
             if done_action.action and done_action.action.calculator_action:
               res["carbon_footprint_reduction"] += done_action.action.calculator_action.average_points

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,6 +1,6 @@
-from django.urls import path, re_path
-from django.conf.urls import url
-from .views import *
+#from django.urls import path, re_path
+#from django.conf.urls import url
+#from .views import *
 
 from api.handlers.action import ActionHandler
 from api.handlers.admin import AdminHandler

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,7 +1,3 @@
-#from django.urls import path, re_path
-#from django.conf.urls import url
-#from .views import *
-
 from api.handlers.action import ActionHandler
 from api.handlers.admin import AdminHandler
 from api.handlers.community import CommunityHandler
@@ -24,9 +20,6 @@ from api.handlers.team import TeamHandler
 from api.handlers.testimonial import TestimonialHandler
 from api.handlers.userprofile import UserHandler
 from api.handlers.vendor import VendorHandler
-
-
-
 
 
 urlpatterns = []

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1352,6 +1352,7 @@ def communities_stats(request):
       communityGoal = communityData["goal"]
       res["households_engaged"] = communityGoal["attained_number_of_households"]
       res["actions_completed"] = communityGoal["attained_number_of_actions"]
+      res["carbon_footprint_reduction"] = communityGoal["attained_carbon_footprint_reduction"]
     
       ans.append(res)
   return Json(ans, errors, do_not_serialize=True)
@@ -1364,15 +1365,16 @@ def community_stats(request, cid):
     community, errors = FETCH.one(Community, args)
     if community:
       res = {"households_engaged": 0, "actions_completed": 0, "users_engaged":0}
-      res["community"] = community.simple_json();
+      res["community"] = community.simple_json()
       users, errors = FETCH.all(UserProfile, {"communities": community.id})
-      res["users_engaged"] = len(users);
+      res["users_engaged"] = len(users)
 
       # changed to fix graph inconsistencies
       communityData = community.full_json()
       communityGoal = communityData["goal"]
       res["households_engaged"] = communityGoal["attained_number_of_households"]
       res["actions_completed"] = communityGoal["attained_number_of_actions"]
+      res["carbon_footprint_reduction"] = communityGoal["attained_carbon_footprint_reduction"]
 
       return Json(res, errors, do_not_serialize=True)
   return Json(None)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1946,7 +1946,7 @@ class HomePageSettings(models.Model):
     carbon_footprint_reduction = 0
     for actionRel in done_actions:
       if actionRel.action and actionRel.action.calculator_action:
-        carbon_footprint_reduction += actionRel.action.calculator_action.average_carbon_score
+        carbon_footprint_reduction += actionRel.action.calculator_action.average_points
     goal["organic_attained_carbon_footprint_reduction"] = carbon_footprint_reduction
 
     res =  self.simple_json()

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -195,9 +195,9 @@ class Goal(models.Model):
   more_info = JSONField(blank=True, null=True)
   is_deleted = models.BooleanField(default=False, blank=True)
 
-
-  def get_status(self):
-    return CHOICES["GOAL_STATUS"][self.status]
+``# BHN - not currently implemented
+  #def get_status(self):
+  #  return CHOICES["GOAL_STATUS"][self.status]
 
   def __str__(self):
     return f"{self.name} {' - Deleted' if self.is_deleted else ''}"
@@ -297,6 +297,8 @@ class Community(models.Model):
     # For Wayland launch, insisting that we show large numbers so people feel good about it.
     goal["attained_number_of_households"] += (RealEstateUnit.objects.filter(community=self).count())
     goal["attained_number_of_actions"] += (UserActionRel.objects.filter(real_estate_unit__community=self, status="DONE").count())
+    #BHN - TODO
+    #goal["attained_carbon_footprint_reduction"] += (UserActionRel.objects.filter(real_estate_unit__community=self, status="DONE").count())
 
     return {
       "id": self.id,

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -195,7 +195,6 @@ class Goal(models.Model):
   more_info = JSONField(blank=True, null=True)
   is_deleted = models.BooleanField(default=False, blank=True)
 
-``# BHN - not currently implemented
   #def get_status(self):
   #  return CHOICES["GOAL_STATUS"][self.status]
 
@@ -1942,7 +1941,13 @@ class HomePageSettings(models.Model):
     # 
     # For Wayland launch, insisting that we show large numbers so people feel good about it.
     goal["organic_attained_number_of_households"] = (RealEstateUnit.objects.filter(community=self.community).count())
-    goal["organic_attained_number_of_actions"] = (UserActionRel.objects.filter(real_estate_unit__community=self.community,status="DONE").count())
+    done_actions = UserActionRel.objects.filter(real_estate_unit__community=self.community,status="DONE")
+    goal["organic_attained_number_of_actions"] = (done_actions.count())
+    carbon_footprint_reduction = 0
+    for actionRel in done_actions:
+      if actionRel.action and actionRel.action.calculator_action:
+        carbon_footprint_reduction += actionRel.action.calculator_action.average_carbon_score
+    goal["organic_attained_carbon_footprint_reduction"] = carbon_footprint_reduction
 
     res =  self.simple_json()
     res['images'] = [i.simple_json() for i in self.images.all()]

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -195,9 +195,6 @@ class Goal(models.Model):
   more_info = JSONField(blank=True, null=True)
   is_deleted = models.BooleanField(default=False, blank=True)
 
-  #def get_status(self):
-  #  return CHOICES["GOAL_STATUS"][self.status]
-
   def __str__(self):
     return f"{self.name} {' - Deleted' if self.is_deleted else ''}"
 


### PR DESCRIPTION
The API includes carbon_footprint_reduction target and attained values the same as it does households and actions completed.  This allows the community portal to show carbon_footprint_reduction graphs (enabled by a community admin by setting target > 0). Also include the attained carbon_footprint_reduction for teams.

Addresses API#110 and Frontend-portal#186