### PR TITLE
Deleted actions shouldn't show in list by default

### DIFF
--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -41,8 +41,7 @@ class ActionStore:
 
       # by default, exclude deleted actions
       #if not context.include_deleted:
-      if True:
-        actions = actions.filter(is_deleted=False)
+      actions = actions.filter(is_deleted=False)
 
       return actions, None
     except Exception as e:

--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -39,9 +39,10 @@ class ActionStore:
       if not context.is_dev:
         actions = actions.filter(is_published=True)
 
-      # may want to add a filter on is_deleted, switched on context
-      # if context.not_if_deleted:
-      #   actions = actions.filter(is_deleted=False)
+      # by default, exclude deleted actions
+      #if not context.include_deleted:
+      if True:
+        actions = actions.filter(is_deleted=False)
 
       return actions, None
     except Exception as e:


### PR DESCRIPTION
Fixes a bug introduced where deleted actions where showing up where they shouldn't have.