### PR TITLE
New members preferred names endpoint

### DIFF
--- a/src/api/handlers/team.py
+++ b/src/api/handlers/team.py
@@ -32,6 +32,7 @@ class TeamHandler(RouteHandler):
     self.add("/teams.messageAdmin", self.message_admin())
     self.add("/teams.contactAdmin", self.message_admin())
     self.add("/teams.members", self.members())
+    self.add("/teams.members.preferredNames", self.members_preferred_names())
 
     #admin routes
     self.add("/teams.listForCommunityAdmin", self.community_admin_list())
@@ -180,6 +181,15 @@ class TeamHandler(RouteHandler):
       return MassenergizeResponse(data=team_members_info)
     return members_view
 
+  def members_preferred_names(self) -> function:
+    def members_preferred_names_view(request) -> None: 
+      context: Context = request.context
+      args: dict = context.args
+      team_members_preferred_names_info, err = self.team.members_preferred_names(context, args)
+      if err:
+        return MassenergizeResponse(error=str(err), status=err.status)
+      return MassenergizeResponse(data=team_members_preferred_names_info)
+    return members_preferred_names_view
 
   def community_admin_list(self) -> function:
     def community_admin_list_view(request) -> None: 

--- a/src/api/services/team.py
+++ b/src/api/services/team.py
@@ -82,6 +82,12 @@ class TeamService:
       return None, err
     return serialize_all(members), None
 
+  def members_preferred_names(self, context, args) -> (dict, MassEnergizeAPIError):
+    preferred_names, err = self.store.members_preferred_names(context, args)
+    if err:
+      return None, err
+    return preferred_names, None
+
   def message_admin(self, context, args) -> (dict, MassEnergizeAPIError):
     message_info, err = self.message_store.message_team_admin(context, args)
     if err:

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -238,6 +238,23 @@ class TeamStore:
       return None, InvalidResourceError()
 
 
+  def members_preferred_names(self, context: Context, args) -> (Team, MassEnergizeAPIError):
+    try:
+      team_id = args.get('team_id', None)
+      if not team_id:
+        return [], CustomMassenergizeError('Please provide a valid team_id')
+
+      members = TeamMember.objects.filter(is_deleted=False, team__id=team_id).select_related("user")
+      res = []
+      for member in members:
+        res.append({"id": member.id, "preferred_name": member.user.preferred_name})
+
+      return res, None
+    except Exception as e:
+      print(e)
+      return None, InvalidResourceError()
+
+
   def list_teams_for_community_admin(self, context: Context, args) -> (list, MassEnergizeAPIError):
     try:
       if context.user_is_super_admin:


### PR DESCRIPTION
For the teams redesign, we want to display the preferred names of the users who are on a given team. This endpoint allows us to access that information without exposing any sensitive data of a user.