### PR TITLE
fix update user

### DIFF
--- a/src/api/handlers/userprofile.py
+++ b/src/api/handlers/userprofile.py
@@ -118,7 +118,7 @@ class UserHandler(RouteHandler):
   def update(self, request):
     context: Context = request.context
     args: dict = context.args
-    user_info, err = self.service.update_user(args.get("id", None), args)
+    user_info, err = self.service.update_user(context, args.get("id", None), args)
     if err:
       return MassenergizeResponse(error=str(err), status=err.status)
     return MassenergizeResponse(data=user_info)

--- a/src/api/services/userprofile.py
+++ b/src/api/services/userprofile.py
@@ -102,8 +102,8 @@ class UserService:
     return serialize(user, full=True), None
 
 
-  def update_user(self, user_id, args) -> (dict, MassEnergizeAPIError):
-    user, err = self.store.update_user(user_id, args)
+  def update_user(self,context, user_id, args) -> (dict, MassEnergizeAPIError):
+    user, err = self.store.update_user(context, user_id, args)
     if err:
       return None, err
     return serialize(user), None


### PR DESCRIPTION
Update user endpoint is returning server_error all the time.

Error:
<img width="950" alt="Screen Shot 2020-09-21 at 10 46 25 PM" src="https://user-images.githubusercontent.com/12572654/93839897-97568d00-fc4b-11ea-97dc-185228e2dd45.png">


This PR fixes that.