### PR TITLE
Handle Update cases where community set to "no community" etc

### DIFF
--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -142,11 +142,15 @@ class ActionStore:
         community = Community.objects.filter(id=community_id).first()
         if community:
           action.community = community
+        else:
+          action.community = None
 
       if calculator_action:
         ccAction = CCAction.objects.filter(pk=calculator_action).first()
         if ccAction:
           action.calculator_action = ccAction
+        else:
+          action.calculator_action = None
         
       action.save()
       return action, None

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -118,7 +118,7 @@ class EventStore:
 
       community = args.pop("community_id", None)
       if community:
-        community = Community.objects.get(pk=community)
+        community = Community.objects.filter(pk=community).first()
       
       events.update(**args)
 
@@ -134,6 +134,8 @@ class EventStore:
       
       if community:
         event.community = community
+      else:
+        event.community = None
       
       event.save()
 

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -232,12 +232,14 @@ class TeamStore:
         team.is_published = is_published
 
       if team:
+        team.community = None
         if community_id:
           community = Community.objects.filter(pk=community_id).first()
           if community:
-            team.community = community
+            team.community = community          
 
         if parent_id:
+          team.parent = None
           parent = Team.objects.filter(pk=parent_id).first()
           if parent and can_set_parent(parent, this_team=team):
             team.parent = parent

--- a/src/api/store/testimonial.py
+++ b/src/api/store/testimonial.py
@@ -143,19 +143,27 @@ class TestimonialStore:
       if image:
         media = Media.objects.create(file=image, name=f"ImageFor{args.get('name', '')}Event")
         new_testimonial.image = media
+      else:
+        new_testimonial.image = None
 
       if action:
-        testimonial_action = Action.objects.get(id=action)
+        testimonial_action = Action.objects.filter(id=action).first()
         new_testimonial.action = testimonial_action
+      else:
+        new_testimonial.action = None
 
       if vendor:
-        testimonial_vendor = Vendor.objects.get(id=vendor)
+        testimonial_vendor = Vendor.objects.filter(id=vendor).first()
         new_testimonial.vendor = testimonial_vendor
+      else:
+        new_testimonial.vendor = None
 
       if community:
-        testimonial_community = Community.objects.get(id=community)
+        testimonial_community = Community.objects.filter(id=community).first()
         new_testimonial.community = testimonial_community
-      
+      else:
+        new_testimonial.community = None
+
       if rank:
         new_testimonial.rank = rank
       


### PR DESCRIPTION
On updating Actions, Testimonials, Events, etc, enable clearing the link to primary community, logo, etc

This goes along with the Admin Portal changes to add "--" to dropdowns