### PR TITLE
download.users: optimize _get_user_teams_cells

### DIFF
--- a/src/api/store/download.py
+++ b/src/api/store/download.py
@@ -166,12 +166,12 @@ class DownloadStore:
 
   def _get_user_teams_cells(self, user, teams):
     if (isinstance(user, Subscriber)):
-      return [''] # for _ in range(len(teams))]
+      return ['']
 
-    teams = teams.filter(
+    user_teams = teams.filter(
       teammember__user=user).values_list('name', 'teammember__is_admin')
     team_names = []
-    for team_name, is_admin in teams:
+    for team_name, is_admin in user_teams:
       team_names.append((team_name + '(ADMIN)') if is_admin else team_name)
     return [', '.join(team_names)]
 

--- a/src/api/tests/test_download.py
+++ b/src/api/tests/test_download.py
@@ -17,11 +17,11 @@ class DownloadTestCase(TestCase):
     self.client = Client()
 
     self.USER, self.CADMIN, self.SADMIN = createUsers()
-    
+
     signinAs(self.client, self.SADMIN)
 
     setupCC(self.client)
-  
+
     COMMUNITY_NAME = "test_downloads"
     self.COMMUNITY = Community.objects.create(**{
       'subdomain': COMMUNITY_NAME,
@@ -76,7 +76,7 @@ class DownloadTestCase(TestCase):
     self.ACTION2.save()
     self.ACTION3.save()
 
-      
+
   @classmethod
   def tearDownClass(self):
     pass
@@ -153,9 +153,21 @@ class DownloadTestCase(TestCase):
     self.assertEqual(len(rows),8)    # two header rows, five data rows, and final empty row
     headerdata = rows[0].split(',')
     self.assertEqual(headerdata[4],'Email')
-    userdata = rows[2].split(',')      # data starts in third row
-    self.assertIn(userdata[4],[self.USER1.email, self.USER2.email, self.CADMIN.email, self.USER.email, self.SADMIN.email])
-
+    self.assertEqual(headerdata[10], 'TEAM')
+    expected_emails_teams = {
+      self.USER1.email: 'The Downloaders(ADMIN)',
+      self.USER2.email: '',
+      self.CADMIN.email: '',
+      self.USER.email: '',
+      self.SADMIN.email: '',
+    }
+    for user_row in rows[2:-1]:  # data starts in third row. last row empty.
+      userdata = user_row.split(',')
+      # pop the team value for a given email
+      team = expected_emails_teams.pop(userdata[4])
+      self.assertEqual(userdata[10], team)
+    # check that we found all expected emails/teams, and none remain
+    self.assertDictEqual(expected_emails_teams, {})
 
   def test_download_actions(self):
     #print("test_download_actions")


### PR DESCRIPTION
This change improves performance of `_get_user_teams_cells`
by replacing a loop that ran multiple database queries. The
new code builds and runs a single query to fetch all the
team names associated with a given user.

Also:
- Improved `test_download.py` to validate team names
- Minor whitespace cleanup

Testing
=======

local runsever
--------------

Ran curl http://localhost:8000/api/downloads.users before and
after change.

Using sample database, download time went from 2+ minutes to
under 12 seconds.

It it likely we can make additional improvements to other
database queries performed by the user download code.

unit tests
----------

```
% ./manage.py test api.tests.test_download.DownloadTestCase
Creating test database for alias 'default'...
Initializing 0 Carbon Calc defaults from db
System check identified no issues (0 silenced).

---> Testing Downloads <---

Sign in as Super Admin
Imported 197 Carbon Calculator Questions
Imported 37 Carbon Calculator Actions
Imported 17 CarbonSaver Stations
Imported 4 CarbonSaver Groups
Imported 5 CarbonSaver Orgs
Imported 3 CarbonSaver Events
No user signed in
Sign in as Regular User
Sign in as Community Admin
Sign in as Super Admin
Sign in as Community Admin
Sign in as Super Admin
...No user signed in
Sign in as Regular User
Sign in as Community Admin
Sign in as Super Admin
Sign in as Community Admin
Sign in as Community Admin
Sign in as Super Admin
downloading 5 users
.
----------------------------------------------------------------------
Ran 4 tests in 50.940s

OK
Destroying test database for alias 'default'...
```

Fixes #259 