### PR TITLE
New menu remake route, and changes to menu

### DIFF
--- a/src/api/handlers/misc.py
+++ b/src/api/handlers/misc.py
@@ -10,97 +10,103 @@ from _main_.utils.context import Context
 from _main_.utils.validator import Validator
 from api.decorators import admins_only, super_admins_only, login_required
 
+
 class MiscellaneousHandler(RouteHandler):
+    def __init__(self):
+        super().__init__()
+        self.service = MiscellaneousService()
+        self.registerRoutes()
 
-  def __init__(self):
-    super().__init__()
-    self.service = MiscellaneousService()
-    self.registerRoutes()
+    def registerRoutes(self) -> None:
+        self.add("/menus.remake", self.remake_navigation_menu)
+        self.add("/menus.list", self.navigation_menu_list)
+        self.add("/data.backfill", self.backfill)
+        self.add("/data.carbonEquivalency.create", self.create_carbon_equivalency)
+        self.add("/data.carbonEquivalency.update", self.update_carbon_equivalency)
+        self.add("/data.carbonEquivalency.get", self.get_carbon_equivalencies)
+        self.add("/data.carbonEquivalency.info", self.get_carbon_equivalencies)
+        self.add("/data.carbonEquivalency.delete", self.delete_carbon_equivalency)
+        self.add("/home", self.home)
+        self.add("", self.home)
 
-  def registerRoutes(self) -> None:
-    self.add("/menus.list", self.navigation_menu_list) 
-    self.add("/data.backfill", self.backfill) 
-    self.add("/data.carbonEquivalency.create", self.create_carbon_equivalency)
-    self.add("/data.carbonEquivalency.update", self.update_carbon_equivalency)
-    self.add("/data.carbonEquivalency.get", self.get_carbon_equivalencies)
-    self.add("/data.carbonEquivalency.info", self.get_carbon_equivalencies)
-    self.add("/data.carbonEquivalency.delete", self.delete_carbon_equivalency)
-    self.add("/home", self.home) 
-    self.add("", self.home) 
+    def remake_navigation_menu(self, request):
+        data, err = self.service.remake_navigation_menu()
+        if err:
+            return MassenergizeResponse(error=err)
+        return MassenergizeResponse(data=data)
 
-  def navigation_menu_list(self, request):
-    context: Context = request.context
-    args: dict = context.args
-    goal_info, err = self.service.navigation_menu_list(context, args)
-    if err:
-      return MassenergizeResponse(error=str(err), status=err.status)
-    return MassenergizeResponse(data=goal_info)
+    def navigation_menu_list(self, request):
+        context: Context = request.context
+        args: dict = context.args
+        goal_info, err = self.service.navigation_menu_list(context, args)
+        if err:
+            return MassenergizeResponse(error=str(err), status=err.status)
+        return MassenergizeResponse(data=goal_info)
 
-  def backfill(self, request):
-    context: Context = request.context
-    args: dict = context.args
-    goal_info, err = self.service.backfill(context, args)
-    if err:
-      return MassenergizeResponse(error=str(err), status=err.status)
-    return MassenergizeResponse(data=goal_info)
+    def backfill(self, request):
+        context: Context = request.context
+        args: dict = context.args
+        goal_info, err = self.service.backfill(context, args)
+        if err:
+            return MassenergizeResponse(error=str(err), status=err.status)
+        return MassenergizeResponse(data=goal_info)
 
+    @super_admins_only
+    def create_carbon_equivalency(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-  @super_admins_only
-  def create_carbon_equivalency(self, request):
-    context: Context = request.context
-    args: dict = context.args
+        carbon_info, err = self.service.create_carbon_equivalency(args)
 
-    carbon_info, err = self.service.create_carbon_equivalency(args)
+        if err:
+            return MassenergizeResponse(error=str(err), status=err.status)
+        return MassenergizeResponse(data=carbon_info)
 
-    if err:
-      return MassenergizeResponse(error=str(err), status=err.status)
-    return MassenergizeResponse(data=carbon_info)
+    @super_admins_only
+    def update_carbon_equivalency(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-  @super_admins_only
-  def update_carbon_equivalency(self, request):
-    context: Context = request.context
-    args: dict = context.args
+        # if id passed, return just one, otherwise all
+        self.validator.expect("id", int, is_required=True)
+        self.validator.rename("carbon_equivalency_id", "id")
+        args, err = self.validator.verify(args)
 
-    # if id passed, return just one, otherwise all
-    self.validator.expect("id", int, is_required=True)
-    self.validator.rename("carbon_equivalency_id", "id")
-    args, err = self.validator.verify(args)
+        carbon_info, err = self.service.update_carbon_equivalency(args)
 
-    carbon_info, err = self.service.update_carbon_equivalency(args)
+        if err:
+            return MassenergizeResponse(error=str(err), status=err.status)
+        return MassenergizeResponse(data=carbon_info)
 
-    if err:
-      return MassenergizeResponse(error=str(err), status=err.status)
-    return MassenergizeResponse(data=carbon_info)
+    def get_carbon_equivalencies(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-  def get_carbon_equivalencies(self, request):
-    context: Context = request.context
-    args: dict = context.args
+        # if id passed, return just one, otherwise all
+        self.validator.expect("id", int)
+        self.validator.rename("carbon_equivalency_id", "id")
+        args, err = self.validator.verify(args)
 
-    # if id passed, return just one, otherwise all
-    self.validator.expect("id", int)
-    self.validator.rename("carbon_equivalency_id", "id")
-    args, err = self.validator.verify(args)
-    
-    carbon_info, err = self.service.get_carbon_equivalencies(args)
+        carbon_info, err = self.service.get_carbon_equivalencies(args)
 
-    if err:
-      return MassenergizeResponse(error=str(err), status=err.status)
-    return MassenergizeResponse(data=carbon_info)
+        if err:
+            return MassenergizeResponse(error=str(err), status=err.status)
+        return MassenergizeResponse(data=carbon_info)
 
-  def delete_carbon_equivalency(self, request):
-    context: Context = request.context
-    args: dict = context.args
+    def delete_carbon_equivalency(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-    self.validator.expect("id", int, is_required=True)
-    self.validator.rename("carbon_equivalency_id", "id")
-    args, err = self.validator.verify(args)
-    
-    carbon_info, err = self.service.delete_carbon_equivalency(args)
+        self.validator.expect("id", int, is_required=True)
+        self.validator.rename("carbon_equivalency_id", "id")
+        args, err = self.validator.verify(args)
 
-    if err:
-      return MassenergizeResponse(error=str(err), status=err.status)
-    return MassenergizeResponse(data=carbon_info)
+        carbon_info, err = self.service.delete_carbon_equivalency(args)
 
-  def home(self, request):
-    context: Context = request.context
-    return self.service.home(context, request)
+        if err:
+            return MassenergizeResponse(error=str(err), status=err.status)
+        return MassenergizeResponse(data=carbon_info)
+
+    def home(self, request):
+        context: Context = request.context
+        return self.service.home(context, request)

--- a/src/api/services/misc.py
+++ b/src/api/services/misc.py
@@ -1,4 +1,7 @@
-from _main_.utils.massenergize_errors import MassEnergizeAPIError, CustomMassenergizeError
+from _main_.utils.massenergize_errors import (
+    MassEnergizeAPIError,
+    CustomMassenergizeError,
+)
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.common import serialize, serialize_all
 from api.store.misc import MiscellaneousStore
@@ -11,91 +14,101 @@ from _main_.utils.utils import load_json, load_text_contents
 from django.db.models.query import QuerySet
 from typing import Tuple
 
+
 class MiscellaneousService:
-  """
-  Service Layer for all the goals
-  """
+    """
+    Service Layer for all the goals
+    """
 
-  def __init__(self):
-    self.store =  MiscellaneousStore()
+    def __init__(self):
+        self.store = MiscellaneousStore()
 
-  
-  def navigation_menu_list(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
-    main_menu_items, err = self.store.navigation_menu_list(context, args)
-    if err:
-      return None, err
-    return serialize_all(main_menu_items), None
-  
-  def backfill(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
-    result, err = self.store.backfill(context, args)
-    if err:
-      return None, err
-    return result, None
+    def remake_navigation_menu(self) -> Tuple[dict, MassEnergizeAPIError]:
+        json = load_json(BASE_DIR + "/database/raw_data/portal/menu.json")
+        return self.store.remake_navigation_menu(json)
 
+    def navigation_menu_list(
+        self, context: Context, args
+    ) -> Tuple[dict, MassEnergizeAPIError]:
+        main_menu_items, err = self.store.navigation_menu_list(context, args)
+        if err:
+            return None, err
+        return serialize_all(main_menu_items), None
 
-  def home(self, ctx: Context, request):
-    deployments = Deployment.objects.all()[:3]
-    build_info = load_json(BASE_DIR + "/_main_/config/build/deployConfig.json")
-    deploy_notes = load_text_contents(BASE_DIR + "/_main_/config/build/deployNotes.txt")
-    
-    deployment = Deployment.objects.filter(version=build_info.get('BUILD_VERSION', "")).first()
-    if deployment:
-      if deployment.notes != deploy_notes:
-        deployment.notes = deploy_notes
-        deployment.save()
-    else:
-      deployment = Deployment.objects.create(
-        version=build_info.get('BUILD_VERSION', ''),
-        notes=deploy_notes
-      )
+    def backfill(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
+        result, err = self.store.backfill(context, args)
+        if err:
+            return None, err
+        return result, None
 
+    def home(self, ctx: Context, request):
+        deployments = Deployment.objects.all()[:3]
+        build_info = load_json(BASE_DIR + "/_main_/config/build/deployConfig.json")
+        deploy_notes = load_text_contents(
+            BASE_DIR + "/_main_/config/build/deployNotes.txt"
+        )
 
-    if IS_PROD:
-      SITE_TITLE = 'MassEnergize-API'
-      SITE_BACKGROUND_COLOR = '#310161'
-      SITE_FONT_COLOR = 'white'
-    elif IS_CANARY:
-      SITE_TITLE = 'CANARY: MassEnergize-API'
-      SITE_BACKGROUND_COLOR = '#310161'
-      SITE_FONT_COLOR = 'white'
-    else:
-      SITE_TITLE = 'DEV: MassEnergize-API'
-      SITE_BACKGROUND_COLOR = '#0b5466'
-      SITE_FONT_COLOR = 'white'
+        deployment = Deployment.objects.filter(
+            version=build_info.get("BUILD_VERSION", "")
+        ).first()
+        if deployment:
+            if deployment.notes != deploy_notes:
+                deployment.notes = deploy_notes
+                deployment.save()
+        else:
+            deployment = Deployment.objects.create(
+                version=build_info.get("BUILD_VERSION", ""), notes=deploy_notes
+            )
 
-    return render(request, 'index.html', {
-        'deployments': deployments,
-        "BUILD_INFO": build_info,
-        "DEPLOY_NOTES": deploy_notes,
-        'SITE_TITLE': SITE_TITLE,
-        'SITE_BACKGROUND_COLOR': SITE_BACKGROUND_COLOR,
-        'SITE_FONT_COLOR': SITE_FONT_COLOR
-      }
-    )
+        if IS_PROD:
+            SITE_TITLE = "MassEnergize-API"
+            SITE_BACKGROUND_COLOR = "#310161"
+            SITE_FONT_COLOR = "white"
+        elif IS_CANARY:
+            SITE_TITLE = "CANARY: MassEnergize-API"
+            SITE_BACKGROUND_COLOR = "#310161"
+            SITE_FONT_COLOR = "white"
+        else:
+            SITE_TITLE = "DEV: MassEnergize-API"
+            SITE_BACKGROUND_COLOR = "#0b5466"
+            SITE_FONT_COLOR = "white"
 
-  def create_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:
-    carbon_data, err = self.store.create_carbon_equivalency(args)
-    if err:
-      return None, err
-    return serialize(carbon_data), None
+        return render(
+            request,
+            "index.html",
+            {
+                "deployments": deployments,
+                "BUILD_INFO": build_info,
+                "DEPLOY_NOTES": deploy_notes,
+                "SITE_TITLE": SITE_TITLE,
+                "SITE_BACKGROUND_COLOR": SITE_BACKGROUND_COLOR,
+                "SITE_FONT_COLOR": SITE_FONT_COLOR,
+            },
+        )
 
-  def update_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:
-    carbon_data, err = self.store.update_carbon_equivalency(args)
-    if err:
-      return None, err
-    return serialize(carbon_data), None
-  
-  def get_carbon_equivalencies(self, args) -> Tuple[dict, MassEnergizeAPIError]:
-    carbon_data, err = self.store.get_carbon_equivalencies(args)
-    if err:
-      return None, err
-    if type(carbon_data)==QuerySet:
-      return serialize_all(carbon_data), None
-    else:
-      return serialize(carbon_data), None
+    def create_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:
+        carbon_data, err = self.store.create_carbon_equivalency(args)
+        if err:
+            return None, err
+        return serialize(carbon_data), None
 
-  def delete_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:
-    carbon_data, err = self.store.delete_carbon_equivalency(args)
-    if err:
-      return None, err
-    return serialize(carbon_data), None
+    def update_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:
+        carbon_data, err = self.store.update_carbon_equivalency(args)
+        if err:
+            return None, err
+        return serialize(carbon_data), None
+
+    def get_carbon_equivalencies(self, args) -> Tuple[dict, MassEnergizeAPIError]:
+        carbon_data, err = self.store.get_carbon_equivalencies(args)
+        if err:
+            return None, err
+        if type(carbon_data) == QuerySet:
+            return serialize_all(carbon_data), None
+        else:
+            return serialize(carbon_data), None
+
+    def delete_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:
+        carbon_data, err = self.store.delete_carbon_equivalency(args)
+        if err:
+            return None, err
+        return serialize(carbon_data), None

--- a/src/database/raw_data/portal/menu.json
+++ b/src/database/raw_data/portal/menu.json
@@ -1,104 +1,115 @@
 {
-    "navLinks": [
+  "PortalMainNavLinks": [
+    {
+      "link": "/",
+      "name": "Home",
+      "navItemId": "menu-home-id"
+    },
+    {
+      "name": "Actions",
+      "navItemId": "menu-actions-id",
+      "children": [
         {
-            "link": "/",
-            "name": "Home"
+          "link": "actions",
+          "name": "All Actions"
         },
         {
-            "name": "Actions",
-            "children": [
-                {
-                    "link": "actions",
-                    "name": "All Actions"
-                },
-                {
-                    "link": "services",
-                    "name": "Service Providers"
-                },
-                {
-                    "link": "testimonials",
-                    "name": "Testimonials"
-                },
-                {
-                    "link": "teams",
-                    "name": "Teams"
-                }
-            ]
+          "link": "services",
+          "name": "Service Providers"
         },
         {
-            "name": "About Us",
-            "children": [
-                {
-                    "link": "/aboutus",
-                    "name": "Our Story"
-                },
-                {
-                    "link": "/impact",
-                    "name": "Impact"
-                },
-                {
-                    "link": "/donate",
-                    "name": "Donate"
-                }
-            ]
+          "link": "testimonials",
+          "name": "Testimonials"
         },
         {
-            "link": "/events",
-            "name": "Events"
+          "link": "teams",
+          "name": "Teams"
         }
-    ],
-    "navBarSticky": false,
-    "footerData": {
-        "footerInfo": {
-            "phone": "617-617-6176",
-            "email": "info@massenergize.com",
-            "contactPerson": "Ellen Tohn",
-            "contactPersonLink": "#"
+      ]
+    },
+    {
+      "name": "About Us",
+      "navItemId": "menu-about-us-id",
+      "children": [
+        {
+          "link": "/aboutus",
+          "name": "Our Story"
         },
-        "footerLinks": {
-            "title": "Quick Links",
-            "links": [
-                {
-                    "link": "home",
-                    "name": "Home"
-                },
-                {
-                    "link": "actions",
-                    "name": "Actions"
-                },
-                {
-                    "link": "services",
-                    "name": "Service Providers"
-                },
-                {
-                    "link": "testimonials",
-                    "name": "Testimonials"
-                },
-                {
-                    "link": "teams",
-                    "name": "Teams"
-                },
-                {
-                    "link": "impact",
-                    "name": "Impact"
-                },
-                {
-                    "link": "events",
-                    "name": "Events"
-                },
-                {
-                    "link": "students",
-                    "name": "For Students"
-                },
-                {
-                    "link": "aboutus",
-                    "name": "About Us"
-                },
-                {
-                    "link": "policies",
-                    "name": "Policies"
-                }
-            ]
+        {
+          "link": "/impact",
+          "name": "Impact"
+        },
+        {
+          "link": "/donate",
+          "name": "Donate"
         }
+      ]
+    },
+    {
+      "link": "/events",
+      "navItemId": "menu-events-id",
+      "name": "Events"
     }
+  ],
+  "PortalFooterContactInfo": {
+    "phone": "617-617-6176",
+    "email": "info@massenergize.com",
+    "contactPerson": "Ellen Tohn",
+    "contactPersonLink": "#"
+  },
+  "PortalFooterQuickLinks": {
+    "title": "Quick Links",
+    "links": [
+      {
+        "link": "home",
+        "navItemId": "footer-home-id",
+        "name": "Home"
+      },
+      {
+        "link": "actions",
+        "navItemId": "footer-actions-id",
+        "name": "Actions"
+      },
+      {
+        "link": "services",
+        "navItemId": "footer-service-providers-id",
+        "name": "Service Providers"
+      },
+      {
+        "link": "testimonials",
+        "navItemId": "footer-testimonials-id",
+        "name": "Testimonials"
+      },
+      {
+        "link": "teams",
+        "navItemId": "footer-teams",
+        "name": "Teams"
+      },
+      {
+        "link": "impact",
+        "navItemId": "footer-impact-id",
+        "name": "Impact"
+      },
+      {
+        "link": "events",
+        "navItemId": "footer-events-id",
+        "name": "Events"
+      },
+      {
+        "link": "students",
+        "navItemId": "footer-students-id",
+        "name": "For Students"
+      },
+      {
+        "link": "aboutus",
+        "navItemId": "footer-about-us-id",
+        "name": "About Us"
+      },
+      {
+        "link": "policies",
+        "navItemId": "footer-policies-id",
+        "name": "Policies"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
New route `api/menus.remake` 
This route uses the content of `menu.json` we have to fill the "menus" table in the database. 

In this PR, I have made changes to the `menu.json` and assigned ids to the menu items.  
These ids  help target the navigation menu when we are testing various functionality via the nav menu. 
Just hit the `api/menus.remake` in dev/canary/prod/ or any mode (on backend) to inflate the menus table with the new data.
_Nothing will change for the frontend_
In future, when we are ready to make more changes to the structure of the menu, we just need to edit the `menu.json` and hit the `api/menus.remake` route to update. 

**DISCLAIMER** 
@BradHN1 , the intended changes happened inside the `menu.json` `misc.py` in (handler, services, store) the rest are just formatting changes 🤣 🤣 🤣 . Nothing is broken, dont be scared.