### PR TITLE
Async Tasks :: Making cadmin and sadmin weekly nudge available on admin portal 

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -95,10 +95,8 @@ celery:
 
 
 beat:
-	DJANGO_ENV=local celery -A _main_.celery.app beat -l info
+	celery -A _main_.celery.app beat -l info
 
 celery-remote:
 	celery -A _main_.celery.app worker -l info
 
-beat:
-	celery -A _main_.celery.app beat -l info

--- a/src/_main_/celery/app.py
+++ b/src/_main_/celery/app.py
@@ -14,10 +14,6 @@ app.autodiscover_tasks()
 
 
 app.conf.beat_schedule = {
-    'generate_and_send_weekly_report': {
-        'task': 'api.tasks.generate_and_send_weekly_report',
-        'schedule': crontab(day_of_week=1, hour=0, minute=0),
-    }
 }
 
 @shared_task(bind=True)

--- a/src/_main_/celery/config.py
+++ b/src/_main_/celery/config.py
@@ -12,7 +12,7 @@ class CeleryConfig:
                 "task_serializer": "json",
                 "result_serializer": "json",
                 "accept_content": ["json"],
-                'celery_beat_scheduler': 'django_celery_beat.schedulers:DatabaseScheduler',
+                'beat_scheduler': 'django_celery_beat.schedulers:DatabaseScheduler',
             }
         else:
             sqs_url = os.environ.get("SQS_AWS_ENDPOINT", None)

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -1,5 +1,4 @@
 import csv
-from django.db.models import Count
 from django.http import HttpResponse
 from _main_.utils.context import Context
 from _main_.utils.emailer.send_email import send_massenergize_email, send_massenergize_email_with_attachments
@@ -7,11 +6,6 @@ from api.constants import ACTIONS, COMMUNITIES, METRICS, TEAMS, USERS
 from api.store.download import DownloadStore
 from celery import shared_task
 from api.store.download import DownloadStore
-from api.utils.constants import CADMIN_EMAIL_TEMPLATE_ID, SADMIN_EMAIL_TEMPLATE_ID
-from database.models import Community, CommunityAdminGroup, CommunityMember, UserActionRel, UserProfile
-from django.utils import timezone
-import datetime
-from django.utils.timezone import utc
 
 
 def generate_csv_and_email(data, download_type, community_name=None, email=None):
@@ -84,72 +78,4 @@ def download_data(self, args, download_type):
             generate_csv_and_email(
                 data=files, download_type=METRICS, community_name=com_name, email=email)
 
-
-@shared_task(bind=True)
-def generate_and_send_weekly_report(self):
-    today = datetime.datetime.utcnow().replace(tzinfo=utc)
-    one_week_ago = today - timezone.timedelta(days=7)
-    super_admins = UserProfile.objects.filter(is_super_admin=True).values_list("email", flat=True)
-
-    communities = Community.objects.all().order_by('is_approved')
-    communities_total_signups = CommunityMember.objects.filter(community__is_approved=True).values('community__name').annotate(signups=Count("community")).order_by('community')
-    communities_weekly_signups = CommunityMember.objects.filter(community__is_approved=True, created_at__gte=one_week_ago).values('community__name').annotate(signups=Count("community")).order_by('community')
-    communities_total_actions = UserActionRel.objects.filter(created_at__gte=one_week_ago).exclude(status='SAVE_FOR_LATER').values('action__community__name', 'carbon_impact').annotate(actions=Count("action__community")).order_by('action__community')
-    communities_weekly_done_actions = UserActionRel.objects.filter(created_at__gte=one_week_ago, created_at__lte=today, status='DONE').values('action__community__name', 'carbon_impact').annotate(actions=Count("action__community")).order_by('action__community')
-    communities_weekly_todo_actions = UserActionRel.objects.filter(created_at__gte=one_week_ago, created_at__lte=today, status="TODO").values('action__community__name', 'carbon_impact').annotate(actions=Count("action__community")).order_by('action__community')
-
-    response = HttpResponse(content_type="text/csv")
-    writer = csv.writer(response)
-    writer.writerow(['Community','Total Signups', 'Signups This Week', 'Total Actions Taken', ' Actions Taken This Week ', 'Actions in ToDo This Week'])
-
-    for community in communities:
-        community_name = community.name
-        all_community_admins = CommunityAdminGroup.objects.filter(community=community).values_list('members__email', flat=True)
-        all_community_admins = list(all_community_admins)
-
-
-
-        total_signups  = communities_total_signups.filter(community__name=community_name).first()
-        community_total_signup = total_signups['signups'] if total_signups else 0
-        weekly_signups = communities_weekly_signups.filter(community__name=community_name).first()
-        community_weekly_signup = weekly_signups['signups'] if weekly_signups else 0
-
-        total_actions = communities_total_actions.filter(action__community__name=community_name).first()
-        community_actions_taken = total_actions['actions'] if total_actions else 0
-
-        weekly_done_actions = communities_weekly_done_actions.filter(action__community__name=community_name).first()
-        community_weekly_done_actions = weekly_done_actions['actions'] if weekly_done_actions else 0
-
-        weekly_todo_actions = communities_weekly_todo_actions.filter(action__community__name=community_name).first()
-        community_weekly_todo_actions = weekly_todo_actions['actions'] if weekly_todo_actions else 0
-
-
-        cadmin_temp_data ={
-            'community': community_name,
-            'signups': community_weekly_signup,
-            'actions_done': community_weekly_done_actions,
-            'actions_todo': community_weekly_todo_actions,
-            'start': str(one_week_ago.date()),
-            'end': str(today.date()),
-
-        }
-        
-
-        send_email(None, None,all_community_admins, CADMIN_EMAIL_TEMPLATE_ID,cadmin_temp_data)
-
-        writer.writerow([community_name, community_total_signup,community_weekly_signup, community_actions_taken, community_weekly_done_actions, community_weekly_todo_actions])
-    
-    sadmin_temp_data =  {
-            'name':"there",
-            'start': str(one_week_ago.date()),
-            'end': str(today.date()),
-        }
-
-    send_email(response.content, f'Weekly Report({one_week_ago.date()} to {today.date()}).csv',list(super_admins), SADMIN_EMAIL_TEMPLATE_ID, sadmin_temp_data )
-    return "success"
-
-
-
-def send_email(file, file_name, email_list, temp_id, t_model):
-    send_massenergize_email_with_attachments(temp_id, t_model, email_list, file, file_name)
 

--- a/src/task_queue/jobs.py
+++ b/src/task_queue/jobs.py
@@ -1,7 +1,8 @@
 
-from task_queue.views import test_function
+from task_queue.views import community_admin_nudge, super_admin_nudge
 
 
 FUNCTIONS = {
-    "test_job": test_function,
+    'Super admin nudge':super_admin_nudge,
+    "Community Admin nudge":community_admin_nudge
 }

--- a/src/task_queue/views.py
+++ b/src/task_queue/views.py
@@ -43,8 +43,8 @@ def super_admin_nudge():
 
     data = query_db()
 
-    # super_admins = UserProfile.objects.filter(is_super_admin=True).values_list("email", flat=True)
-    super_admins = ['abdullai.tahiru@gmail.com']
+    super_admins = UserProfile.objects.filter(is_super_admin=True).values_list("email", flat=True)
+
     for community in communities:
         community_name = community.name
         all_community_admins = CommunityAdminGroup.objects.filter(community=community).values_list('members__email', flat=True)
@@ -87,7 +87,7 @@ def community_admin_nudge():
         community_name = community.name
 
         all_community_admins = CommunityAdminGroup.objects.filter(community=community).values_list('members__email', flat=True)
-        all_community_admins = list(all_community_admins)
+        cadmin_email_list = list(all_community_admins)
 
         weekly_signups = data.get('weekly_sign_ups').filter(community__name=community_name).first()
         community_weekly_signup = weekly_signups['signups'] if weekly_signups else 0
@@ -111,7 +111,7 @@ def community_admin_nudge():
         }
         
 
-        send_nudge(None, None,["abdullai.tahiru@gmail.com"], CADMIN_EMAIL_TEMPLATE_ID,temp_data)
+        send_nudge(None, None,cadmin_email_list, CADMIN_EMAIL_TEMPLATE_ID,temp_data)
     return "Success"
 
 

--- a/src/task_queue/views.py
+++ b/src/task_queue/views.py
@@ -1,8 +1,120 @@
+import csv
+from django.http import HttpResponse
+from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
+from api.utils.constants import CADMIN_EMAIL_TEMPLATE_ID, SADMIN_EMAIL_TEMPLATE_ID
+from database.models import *
+from django.utils import timezone
+import datetime
+from django.utils.timezone import utc
+from django.db.models import Count
+
+today = datetime.datetime.utcnow().replace(tzinfo=utc)
+one_week_ago = today - timezone.timedelta(days=7)
+communities = Community.objects.all().order_by('is_approved')
+
+def query_db():
+    """
+    Query data from the database.
+    """
+    communities_total_signup = CommunityMember.objects.filter(community__is_approved=True).values('community__name').annotate(signups=Count("community")).order_by('community')
+    communities_weekly_signup = CommunityMember.objects.filter(community__is_approved=True, created_at__gte=one_week_ago).values('community__name').annotate(signups=Count("community")).order_by('community')
+    communities_total_actions = UserActionRel.objects.filter(created_at__gte=one_week_ago).exclude(status='SAVE_FOR_LATER').values('action__community__name', 'carbon_impact').annotate(actions=Count("action__community")).order_by('action__community')
+    communities_weekly_done_actions = UserActionRel.objects.filter(created_at__gte=one_week_ago, created_at__lte=today, status='DONE').values('action__community__name', 'carbon_impact').annotate(actions=Count("action__community")).order_by('action__community')
+    communities_weekly_todo_actions = UserActionRel.objects.filter(created_at__gte=one_week_ago, created_at__lte=today, status="TODO").values('action__community__name', 'carbon_impact').annotate(actions=Count("action__community")).order_by('action__community')
+    return {
+        'total_sign_ups': communities_total_signup,
+        'weekly_sign_ups': communities_weekly_signup,
+        'total_actions': communities_total_actions,
+        'weekly_done_actions': communities_weekly_done_actions,
+        'weekly_todo_actions': communities_weekly_todo_actions,
+     }
 
 
 
-def test_function():
-    print("-------------test_function-------------")
-    return True,
 
 
+def super_admin_nudge():
+    """
+    Send a nudge to super admins.
+    """
+    response = HttpResponse(content_type="text/csv")
+    writer = csv.writer(response)
+    writer.writerow(['Community','Total Signups', 'Signups This Week', 'Total Actions Taken', ' Actions Taken This Week ', 'Actions in ToDo This Week'])
+
+    data = query_db()
+
+    # super_admins = UserProfile.objects.filter(is_super_admin=True).values_list("email", flat=True)
+    super_admins = ['abdullai.tahiru@gmail.com']
+    for community in communities:
+        community_name = community.name
+        all_community_admins = CommunityAdminGroup.objects.filter(community=community).values_list('members__email', flat=True)
+        all_community_admins = list(all_community_admins)
+
+        total_signup  = data.get('total_sign_ups').filter(community__name=community_name).first()
+        community_total_signup = total_signup['signups'] if total_signup else 0
+
+        weekly_signup = data.get('weekly_sign_ups').filter(community__name=community_name).first()
+        community_weekly_signup = weekly_signup['signups'] if weekly_signup else 0
+
+        total_actions = data.get('total_actions').filter(action__community__name=community_name).first()
+        community_actions_taken = total_actions['actions'] if total_actions else 0
+
+        weekly_done_actions = data.get('weekly_done_actions').filter(action__community__name=community_name).first()
+        community_weekly_done_actions = weekly_done_actions['actions'] if weekly_done_actions else 0
+
+        weekly_todo_actions = data.get('weekly_todo_actions').filter(action__community__name=community_name).first()
+        community_weekly_todo_actions = weekly_todo_actions['actions'] if weekly_todo_actions else 0
+    
+
+        writer.writerow([community_name, community_total_signup,community_weekly_signup, community_actions_taken, community_weekly_done_actions, community_weekly_todo_actions])
+    
+    temp_data =  {
+            'name':"there",
+            'start': str(one_week_ago.date()),
+            'end': str(today.date()),
+        }
+
+    send_nudge(response.content, f'Weekly Report({one_week_ago.date()} to {today.date()}).csv',list(super_admins), SADMIN_EMAIL_TEMPLATE_ID,temp_data )
+    return "success"
+
+
+
+
+def community_admin_nudge():
+    data = query_db()
+
+    for community in communities:
+        community_name = community.name
+
+        all_community_admins = CommunityAdminGroup.objects.filter(community=community).values_list('members__email', flat=True)
+        all_community_admins = list(all_community_admins)
+
+        weekly_signups = data.get('weekly_sign_ups').filter(community__name=community_name).first()
+        community_weekly_signup = weekly_signups['signups'] if weekly_signups else 0
+
+        weekly_done_actions = data.get('weekly_done_actions').filter(action__community__name=community_name).first()
+        community_weekly_done_actions = weekly_done_actions['actions'] if weekly_done_actions else 0
+
+        weekly_todo_actions = data.get('weekly_todo_actions').filter(action__community__name=community_name).first()
+        community_weekly_todo_actions = weekly_todo_actions['actions'] if weekly_todo_actions else 0
+        
+
+
+        temp_data ={
+            'community': community_name,
+            'signups': community_weekly_signup,
+            'actions_done': community_weekly_done_actions,
+            'actions_todo': community_weekly_todo_actions,
+            'start': str(one_week_ago.date()),
+            'end': str(today.date()),
+
+        }
+        
+
+        send_nudge(None, None,["abdullai.tahiru@gmail.com"], CADMIN_EMAIL_TEMPLATE_ID,temp_data)
+    return "Success"
+
+
+
+def send_nudge(file, file_name, email_list, temp_id, t_model):
+    send_massenergize_email_with_attachments(temp_id, t_model, email_list, file, file_name)


### PR DESCRIPTION
#### Summary / Highlights

- Made super admin and cadmin nudges as separate entities.  Super admins can now toggle either of them off or on and can also reschedule any of them on the admin portal.
- organized the code 

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
