### PR TITLE
tags in actions will get copied over, and tweaks to action serializer

### DIFF
--- a/src/api/handlers/action.py
+++ b/src/api/handlers/action.py
@@ -58,7 +58,7 @@ class ActionHandler(RouteHandler):
     (self.validator
       .expect("community_id", int, is_required=False)
       .expect("calculator_action", int, is_required=False)
-      .expect("image", "file", is_required=False, options={"is_logo": True})
+      .expect("image", "str_list", is_required=False, options={"is_logo": True})
       .expect("title", str, is_required=True, options={"min_length": 4, "max_length": 40})
       .expect("rank", int, is_required=False)
       .expect("is_global", bool, is_required=False)

--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -124,6 +124,8 @@ class ActionStore:
       if not action_to_copy:
         return None, InvalidResourceError()
 
+      tags = action_to_copy.tags.all() 
+      vendors = action_to_copy.vendors.all()
       # the copy will have "-Copy" appended to the name; if that already exists, delete it first
       new_title = get_new_title(None, action_to_copy.title) + "-Copy"
       existing_action = Action.objects.filter(title=new_title, community=None).first()
@@ -158,10 +160,10 @@ class ActionStore:
 
       new_action.save()
 
-      for tag in action_to_copy.tags.all():
+      for tag in tags:
         new_action.tags.add(tag)
 
-      for vendor in action_to_copy.vendors.all():
+      for vendor in vendors:
         new_action.vendors.add(vendor)
         
       new_action.save()

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1594,11 +1594,10 @@ class Action(models.Model):
         data["image"] = get_json_if_not_none(self.image)
         data["calculator_action"] = get_summary_info(self.calculator_action)
         data["tags"] = [t.simple_json() for t in self.tags.all()]
-        #data["steps_to_take"] = self.steps_to_take
-        #data["deep_dive"] = self.deep_dive
-        #data["about"] = self.about
         data["community"] = get_summary_info(self.community)
-        #data["vendors"] = [v.info() for v in self.vendors.all()]
+        #if we dont add this, so that vendors will be preselected when creating/updating action. 
+        #List of vendors will typically not be that long, so this doesnt pose any problems
+        data["vendors"] = [v.info() for v in self.vendors.all()]
         return data
 
     def full_json(self):
@@ -1608,7 +1607,7 @@ class Action(models.Model):
         #data["about"] = self.about
         data["geographic_area"] = self.geographic_area
         data["properties"] = [p.simple_json() for p in self.properties.all()]
-        data["vendors"] = [v.simple_json() for v in self.vendors.all()]
+        # data["vendors"] = [v.simple_json() for v in self.vendors.all()]
         if self.user:
             data["user_email"] = self.user.email
         return data


### PR DESCRIPTION
Related Ticket :  https://github.com/massenergize/api/issues/542

- [x] Tags on actions will get copied over when copying an action 
- [x] Also found that creating action with media library was not selecting the right image, fixed that
- [x] Few mods to actions model to show vendors in simple_json

https://user-images.githubusercontent.com/26961591/180138783-510d3392-0e66-4423-a21f-f6bf7127e371.mov


