### PR TITLE
tiny tweak to allow primary contact to be admin automatically

### DIFF
--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -714,7 +714,9 @@ class CommunityStore:
 
             owner_email = args.get("owner_email", None)
             if owner_email:
-                owner = UserProfile.objects.filter(email=owner_email).first()
+                owner = UserProfile.objects.filter(email=owner_email) 
+                owner.update(is_community_admin = True)
+                owner = owner.first()
                 if owner:
                     comm_admin.members.add(owner)
                     comm_admin.save()


### PR DESCRIPTION
Related to ticket #553  

This change will now make primary contact an admin of the community, as described in the ticket. 

- User is already added  into communityAdminGroup already, so we just had to flip the is_admin property

closes #553 