### PR TITLE
Update UserProfile Django admin page and make existing usernames unique

### DIFF
--- a/src/_main_/settings.py
+++ b/src/_main_/settings.py
@@ -101,6 +101,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rangefilter',
 ]
 
 MIDDLEWARE = [

--- a/src/database/admin.py
+++ b/src/database/admin.py
@@ -6,13 +6,13 @@ from _main_.utils.constants import GLOBAL_SITE_SETTINGS
 from _main_.utils.utils import get_all_models
 
 from database.models import UserProfile
-from database.views import unique_usernames_cleanup, make_usernames_not_unique
+from database.views import make_selected_usernames_unique, make_usernames_not_unique
 
 #changing the default django site name
 admin.site.site_header = GLOBAL_SITE_SETTINGS["ADMIN_SITE_HEADER"]
 
 class UserProfileAdmin(admin.ModelAdmin):
-    actions = [unique_usernames_cleanup, make_usernames_not_unique]
+    actions = [make_selected_usernames_unique, make_usernames_not_unique]
 admin.site.register(UserProfile, UserProfileAdmin)
 
 

--- a/src/database/admin.py
+++ b/src/database/admin.py
@@ -7,12 +7,22 @@ from _main_.utils.utils import get_all_models
 
 from database.models import UserProfile
 from database.views import make_selected_usernames_unique, make_usernames_not_unique
-
+from rangefilter.filters import DateRangeFilter
 #changing the default django site name
 admin.site.site_header = GLOBAL_SITE_SETTINGS["ADMIN_SITE_HEADER"]
 
 class UserProfileAdmin(admin.ModelAdmin):
     actions = [make_selected_usernames_unique, make_usernames_not_unique]
+    list_display = ('full_name', 'email', 'all_communities')
+    search_fields = ['email', 'full_name']
+    list_filter = [('created_at', DateRangeFilter), 'communities', 'is_super_admin', 'is_community_admin', 'is_vendor']
+    date_hierarchy = 'created_at'
+
+    # can specify searchbox placeholder text in Django v4
+    # search_help_text = "Search by email or full name"
+
+    def all_communities(self, obj):
+        return ", ".join([c.name for c in obj.communities.all()])
 admin.site.register(UserProfile, UserProfileAdmin)
 
 

--- a/src/database/admin.py
+++ b/src/database/admin.py
@@ -5,8 +5,15 @@ import inspect
 from _main_.utils.constants import GLOBAL_SITE_SETTINGS
 from _main_.utils.utils import get_all_models
 
+from database.models import UserProfile
+from database.views import unique_usernames_cleanup, make_usernames_not_unique
+
 #changing the default django site name
 admin.site.site_header = GLOBAL_SITE_SETTINGS["ADMIN_SITE_HEADER"]
+
+class UserProfileAdmin(admin.ModelAdmin):
+    actions = [unique_usernames_cleanup, make_usernames_not_unique]
+admin.site.register(UserProfile, UserProfileAdmin)
 
 
 def register_all_models():

--- a/src/database/views.py
+++ b/src/database/views.py
@@ -1,7 +1,58 @@
 from django.shortcuts import render
+from database.models import UserProfile
 
 # Create your views here.
 
 #class UserAvatarUpload(APIView):
 #    permission_classes = [permissions.IsAuthenticated]
 #    parser_classes - [MultiPartParser, FormParser]
+def make_usernames_not_unique(self, request, qs):
+    for user in qs:
+        user.preferred_name = "md"
+        user.save()
+
+def unique_usernames_cleanup(self, request, qs):
+    # key is username, value is list of UserProfile objects with that username
+    usernames = {}
+    
+    # stores the usernames that belong to more than one user 
+    non_unique_usernames = set()
+
+    # users = UserProfile.objects.all()
+    for user in qs:
+        name = user.preferred_name
+
+        if name in usernames:
+            usernames[name].append(user)
+            non_unique_usernames.add(name)
+        else:
+            usernames[name] = [user]
+    
+    # printing out non-unqiue usernames
+    for name in non_unique_usernames:
+        print("Username '{}' is held by:".format(name))
+        
+        names = usernames[name]
+        for n in names:
+            print("\t{} - {}".format(n.full_name, n.email))
+
+    # updating non-unique usernames
+    for name in non_unique_usernames:
+        names = usernames[name][1:] # the first UserProfile can keep their original username
+        num = 1 # start at 1 or 0?
+
+        for n in names:
+            # generating new username
+            new_username = n.preferred_name + "-" + str(num)
+            while new_username in usernames.keys():
+                num += 1
+                new_username = n.preferred_name + "-" + str(num)
+
+            # updating 'usernames' to have the newly created ones
+            usernames[new_username] = n
+            
+            print("Changing username of {} from {} to {}".format(n.email, n.preferred_name, new_username))
+            n.preferred_name = new_username
+            n.save()
+
+    # TODO: send email to users informing them of username change

--- a/src/database/views.py
+++ b/src/database/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from database.models import UserProfile
+from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 
 # Create your views here.
 
@@ -11,7 +12,7 @@ def make_usernames_not_unique(self, request, qs):
         user.preferred_name = "md"
         user.save()
 
-def unique_usernames_cleanup(self, request, qs):
+def make_selected_usernames_unique(self, request, qs):
     # key is username, value is list of UserProfile objects with that username
     usernames = {}
     
@@ -19,6 +20,8 @@ def unique_usernames_cleanup(self, request, qs):
     non_unique_usernames = set()
 
     # users = UserProfile.objects.all()
+    # if 'qs' is used instead of 'users', superadmin MUST select al users in admin page
+
     for user in qs:
         name = user.preferred_name
 
@@ -55,4 +58,13 @@ def unique_usernames_cleanup(self, request, qs):
             n.preferred_name = new_username
             n.save()
 
-    # TODO: send email to users informing them of username change
+            # sending email to user informing of change
+            template_model = {
+                'name'         : n.full_name.split(" ")[0], # just gets first name, is full name better?
+                'new_username' : new_username,
+                'old_username' : name
+            }
+            to = "mattia.danese@massenergize.org" # n.email
+            template_id = 28696806
+            
+            send_massenergize_email_with_attachments(template_id, template_model, to, None, None)


### PR DESCRIPTION
####  Summary / Highlights
Adds filters and search box to the `UserProfile` Django admin page.
`UserProfile` Django admin page function that identifies all users that don't have a unique username, changes a user's username if not unique (to the next closest unique username), and sends user an email informing them of their username being changed (with Postmark).

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
In Django admin page, `UserProfile`'s can now be filtered based on community, email, full name, date range, and roles.
`UserProfile` Django admin page function goes through all `UserProfile` usernames and keeps track of all usernames in order to identify which users, if any, have a non-unique username.
If a user has non-unique username, then next closest username (determined with adding a number to the end, like the "suggesting username" feature in SignUp page) is assigned to them and they are sent an email clearly stating their username was changed.

Notes: 
- `src/database/views.py:67` needs to ultimately changed to `n.email`, for testing purposes I was sending the Postmark email to myself. Change this to your email if you are testing.
- The PostMark email template needs to be finalized

#### Testing Steps (Provide details on how your changes can be tested)
Ensure known unique usernames are not changed and no email is sent to those users.
Ensure known non-unique usernames are changed (to the correct next-closest username) and an email is sent to the correct user informing them of this change.

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [x] I moved the linked issue to "QA Verification" now that it is ready to merge.
