### PR TITLE
Continue brads preference changes

### DIFF
--- a/src/api/handlers/download.py
+++ b/src/api/handlers/download.py
@@ -20,6 +20,8 @@ class DownloadHandler(RouteHandler):
     self.add("/downloads.communities", self.communities_download)
     self.add("/downloads.teams", self.teams_download)
     self.add("/downloads.metrics", self.metrics_download)
+    self.add("/downloads.cadmin_report", self.send_cadmin_report)
+    self.add("/downloads.sadmin_report", self.send_sadmin_report)
     
 
   @admins_only
@@ -74,6 +76,28 @@ class DownloadHandler(RouteHandler):
     community_id = args.pop('community_id', None)
 
     communities_data, err = self.service.metrics_download(context, args, community_id)
+    if err:
+      return MassenergizeResponse(error=str(err), status=err.status)
+    return MassenergizeResponse(data={}, status=200)
+
+  @admins_only
+  def send_cadmin_report(self, request):
+    context: Context = request.context
+    args: dict = context.args
+    community_id = args.pop('community_id', None)
+
+    report, err = self.service.send_cadmin_report(context, community_id=community_id)
+    print(report)
+    if err:
+      return MassenergizeResponse(error=str(err), status=err.status)
+    return MassenergizeResponse(data={}, status=200)
+
+  @admins_only
+  def send_sadmin_report(self, request):
+    context: Context = request.context
+    args: dict = context.args
+
+    report, err = self.service.send_sadmin_report(context)
     if err:
       return MassenergizeResponse(error=str(err), status=err.status)
     return MassenergizeResponse(data={}, status=200)

--- a/src/api/handlers/misc.py
+++ b/src/api/handlers/misc.py
@@ -31,7 +31,9 @@ class MiscellaneousHandler(RouteHandler):
         self.add("/home", self.home)
         self.add("/auth.login.testmode", self.authenticateFrontendInTestMode)
         self.add("", self.home)
-        self.add("/settings.list", self.fetch_available_settings)
+        # settings should be called preferences
+        self.add("/preferences.list", self.fetch_available_preferences)
+        self.add("/settings.list", self.fetch_available_preferences)
         self.add("/what.happened", self.fetch_footages)
 
     def fetch_footages(self, request):
@@ -41,11 +43,11 @@ class MiscellaneousHandler(RouteHandler):
             return MassenergizeResponse(error=error)
         return MassenergizeResponse(data=footages)
 
-    def fetch_available_settings(self, request):
+    def fetch_available_preferences(self, request):
         context: Context = request.context
         if context.user_is_admin():
-            return MassenergizeResponse(data=AdminPortalSettings.Settings)
-        return MassenergizeResponse(data=UserPortalSettings.Settings)
+            return MassenergizeResponse(data=AdminPortalSettings.Preferences)
+        return MassenergizeResponse(data=UserPortalSettings.Preferences)
 
     def remake_navigation_menu(self, request):
         data, err = self.service.remake_navigation_menu()

--- a/src/api/services/download.py
+++ b/src/api/services/download.py
@@ -66,3 +66,27 @@ class DownloadService:
 
         download_data.delay(data, METRICS)
         return [], None
+
+    # these two routines don't do what they should do, which is to send a copy of the nudge report to cadmins or sadmins
+    
+    def send_cadmin_report(self, context: Context, community_id=None) -> Tuple[list, MassEnergizeAPIError]:
+        data = {
+            'community_id': community_id,
+            'user_is_community_admin': context.user_is_community_admin,
+            'user_is_super_admin':context.user_is_super_admin,
+            'email': context.user_email,
+            'user_is_logged_in': context.user_is_logged_in
+        }
+        download_data.delay(data, USERS)
+        return [], None
+
+    def send_sadmin_report(self, context: Context) -> Tuple[list, MassEnergizeAPIError]:
+        data = {
+            'user_is_community_admin': context.user_is_community_admin,
+            'user_is_super_admin':context.user_is_super_admin,
+            'email': context.user_email,
+            'user_is_logged_in': context.user_is_logged_in
+        }
+        download_data.delay(data, USERS)
+        return [], None
+

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -897,7 +897,7 @@ class CommunityStore:
             user = UserProfile.objects.get(pk=context.user_id)
             admin_groups = user.communityadmingroup_set.all()
             ids = [a.community.id for a in admin_groups]
-            communities = Community.objects.filter().exclude(id__in = ids).order_by("name")
+            communities = Community.objects.filter(is_published=True).exclude(id__in = ids).order_by("name")
             return communities, None
 
     def list_communities_for_community_admin(

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -895,9 +895,10 @@ class CommunityStore:
         self, context: Context
     ) -> Tuple[list, MassEnergizeAPIError]:
             user = UserProfile.objects.get(pk=context.user_id)
-            admin_groups = user.communityadmingroup_set.all()
-            ids = [a.community.id for a in admin_groups]
-            communities = Community.objects.filter(is_published=True).exclude(id__in = ids).order_by("name")
+            # admin_groups = user.communityadmingroup_set.all()
+            # ids = [a.community.id for a in admin_groups]
+            # communities = Community.objects.filter(is_published=True).exclude(id__in = ids).order_by("name")
+            communities = Community.objects.filter(is_published=True).order_by("name")
             return communities, None
 
     def list_communities_for_community_admin(

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -688,15 +688,16 @@ class EventStore:
       events = []
       admin_of = []
       user = UserProfile.objects.filter(email=context.user_email).first()
+      today = datetime.datetime.today()
       if user: 
         admin_of =[g.community.id for g in user.communityadmingroup_set.all() ]
     
       if excluded: 
         # Find all events that are open in any community, but exclude events from the selected communities
-        events = Event.objects.filter(Q(publicity = EventConstants.open(), is_global = False) | Q(publicity=EventConstants.open_to(),communities_under_publicity__id__in = admin_of)).exclude(community__id__in = ids).order_by("-id") 
+        events = Event.objects.filter(Q(start_date_and_time__gte=today, is_published = True,publicity = EventConstants.open(), is_global = False) | Q(start_date_and_time__gte=today,is_published = True,publicity=EventConstants.open_to(),communities_under_publicity__id__in = admin_of)).exclude(community__id__in = ids).order_by("-id") 
       else: 
         # Find events that have publicity as open, and belong to the selected community, OR, find events that from any of the listed communities that are open to any of the admins communities
-        events =  Event.objects.filter(Q(community__id__in = ids,publicity = EventConstants.open(), is_global = False) | Q(community__id__in = ids, publicity = EventConstants.open_to(),communities_under_publicity__id__in = admin_of, is_global = False)).distinct().order_by("-id")
+        events =  Event.objects.filter(Q(start_date_and_time__gte=today,is_published = True,community__id__in = ids,publicity = EventConstants.open(), is_global = False) | Q(start_date_and_time__gte=today,is_published = True,community__id__in = ids, publicity = EventConstants.open_to(),communities_under_publicity__id__in = admin_of, is_global = False)).distinct().order_by("-id")
       return events, None
     except Exception as e: 
       capture_message(str(e), level="error")

--- a/src/database/utils/settings/admin_settings.py
+++ b/src/database/utils/settings/admin_settings.py
@@ -1,21 +1,44 @@
 class AdminPortalSettings:
-    Settings = {
-        "general_settings": {
+    Preferences = {
+        "communication_prefs": {
             "live": True,
-            "name": "General Settings",
+            "name": "Communication preferences",
             "options": {
-                "notifications": {
+                "reports_frequency": {
                     "live": True,
                     "text": "How often would you like to receive community reports?",
+                    "explanation": "These are automated reports summarizing recent activities in your community.",
+                    "type": "radio",
                     "values": {
-                        "immediately": {"name": "Immediately", "value": False},
-                        "daily": {"name": "Daily", "value": False},
-                        "weekly": {"name": "Weekly", "value": False},
-                        "monthly": {"name": "Monthly", "value": False},
-                    },
+                        #"immediately": {"name": "Immediately", "value": False},
+                        #"daily": {"name": "Daily", "value": False},
+                        "weekly": {"name": "Once a week", "value": False},
+                        "biweekly": {"name": "Every two weeks", "value": False},
+                        "monthly": {"name": "Once a month", "value": False},
+                        "never": {"name": "Never", "value": False},
+                   },
                 },
-                "in_community_preferences": {
+                #   Add a button to send an example report on click
+                #
+                "send_report_now": {
                     "live": True,
+                    "type": "button",
+                    "text": "Send a sample report to your e-mail",
+                    #"action": "summary.send_admin_report",
+                #
+                #   Two options - button could bring up dialog where they could choose the time period (start and end)
+                #   or user would select which report to get from one of the four choices below.
+                #
+                    #"values": {
+                    #    "daily": {"name": "Last 24 hours", "value": False},
+                    #    "weekly": {"name": "This past week", "value": False},
+                    #    "biweekly": {"name": "Every two weeks", "value": False},
+                    #    "monthly": {"name": "This past month", "value": False},
+                    #    "yearly": {"name": "This past year", "value": False},
+                    #},
+                },
+                "in_community_notifications": {
+                    "live": False,
                     "type": "checkbox",
                     "text": "Within my community; I wish to receive notifications about the following when they happen (select all that apply)",
                     "values": {
@@ -46,7 +69,7 @@ class AdminPortalSettings:
                     },
                 },
                 "general_community_peferences": {
-                    "live": True,
+                    "live": False,
                     "type": "checkbox",
                     "text": "In all communities; I wish to receive notification about the following when they happen (select all that apply)",
                     "values": {
@@ -94,8 +117,8 @@ class AdminPortalSettings:
     }
 
     Defaults = {
-        "general_settings": {
-            "notifications": {"weekly": {"value": True}},
+        "communication_prefs": {
+            "reports_frequency": {"weekly": {"value": True}},
             "user_updates": {"by_email_only": {"value": True}},
             "specific_notifications": {
                 "new_member_update": {
@@ -105,7 +128,7 @@ class AdminPortalSettings:
                     "value": True,
                 },
                 "event_RSVP_update": {
-                    "value": True,
+                    "value": False,
                 },
                 "new_event_creation_update": {
                     "value": True,

--- a/src/database/utils/settings/admin_settings.py
+++ b/src/database/utils/settings/admin_settings.py
@@ -24,6 +24,7 @@ class AdminPortalSettings:
                     "live": True,
                     "type": "button",
                     "text": "Send a sample report to your e-mail",
+                     "function_key":"sendReportToAdmin"
                     #"action": "summary.send_admin_report",
                 #
                 #   Two options - button could bring up dialog where they could choose the time period (start and end)

--- a/src/database/utils/settings/user_settings.py
+++ b/src/database/utils/settings/user_settings.py
@@ -1,4 +1,5 @@
 common_options = {
+    # disable the as_posted until it functions
     "as_posted": {
         "name": "As posted",
         "value": False,
@@ -8,7 +9,7 @@ common_options = {
         "value": False,
     },
     "per_week": {
-        "name": "As summary per week",
+        "name": "A summary per week",
         "value": False,
     },
     "per_month": {
@@ -18,12 +19,12 @@ common_options = {
     "never": {"name": "Never", "value": False},
 }
 
+# this needs work
 
 class UserPortalSettings:
-
-    Settings = {
-        "notification_settings": {
-            "name": "Notification Settings",
+    Preferences = {
+        "communication_prefs": {
+            "name": "Communication Preferences",
             "live": True,
             "options": {
                 "update_frequency": {
@@ -35,7 +36,7 @@ class UserPortalSettings:
                 "news_letter": {
                     "live":True,
                     "type": "radio",
-                    "text": "Send me news  updates in my community",
+                    "text": "Send me news updates in my community",
                     "values": {
                         "as_posted": {"name": "As posted", "value": False},
                         "never": {"name": "Never", "value": False},
@@ -56,8 +57,8 @@ class UserPortalSettings:
                 },
             },
         },
-        "advanced_settings": {
-            "name": "Advanced Settings",
+        "notifications": {
+            "name": "Notifications",
             "live": False,
             "options": {
                 "upcoming_events": {
@@ -95,12 +96,12 @@ class UserPortalSettings:
     }
 
     Defaults = {
-        "general_settings": {
+        "communication_prefs": {
             "update_frequency": {"per_week": {"value": True}},
             "news_letter": {"as_posted": {"value": True}},
             "messaging": {"yes": {"value": True}},
         },
-        "advanced_settings": {
+        "notifications": {
             "upcoming_events": {"never": {"value": True}},
             "upcoming_actions": {"never": {"value": True}},
             "news_teams": {"never": {"value": True}},


### PR DESCRIPTION
## Works with Admin frontend PR - https://github.com/massenergize/frontend-admin/pull/782

- [x] Event list for sharing will now show only live and future events 
- [x] Communities for sharing will also be only live communities 

NB: Automated tests will fail, cos the old tests dont cater for the new changes yet! ( Will be done soon)