### PR TITLE
Show admins what todo 2

### DIFF
--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -106,11 +106,14 @@ def rename_fields(args, pairs):
   return args
 
 
-def serialize_all(data, full=False):
+def serialize_all(data, full=False, **kwargs):
+  medium = (kwargs or {}).get("medium", False)
   if not data:
     return []
   if full:
     return [d.full_json() for d in data]
+  elif medium: 
+    return [d.medium_json() for d in data]
   return [d.simple_json() for d in data]
 
 

--- a/src/_main_/utils/footage/FootageConstants.py
+++ b/src/_main_/utils/footage/FootageConstants.py
@@ -103,7 +103,7 @@ class FootageConstants:
 
     @staticmethod
     def on_user_portal():
-        return PLATFORMS["ADMIN_FRONTEND_PORTAL"]["key"]
+        return PLATFORMS["USER_FRONTEND_PORTAL"]["key"]
 
     @staticmethod
     def create():

--- a/src/_main_/utils/footage/spy.py
+++ b/src/_main_/utils/footage/spy.py
@@ -291,11 +291,14 @@ class Spy:
                 else UserProfile.objects.filter(email=ctx.user_email).first()
             )
             act_type = kwargs.get("type", None)
+            portal = kwargs.get("portal", None)
+            portal = portal if portal else FootageConstants.on_admin_portal()
             footage = Spy.create_footage(
                 actor=actor,
                 activity_type=act_type,
                 by_super_admin=ctx.user_is_super_admin,
                 item_type=FootageConstants.ITEM_TYPES["AUTH"]["key"],
+                portal = portal
             )
             groups = actor.communityadmingroup_set.all()
             communities = [g.community for g in groups]

--- a/src/_main_/utils/footage/spy.py
+++ b/src/_main_/utils/footage/spy.py
@@ -349,7 +349,7 @@ class Spy:
         return (
             Footage.objects.filter(
                 portal=FootageConstants.on_admin_portal(), by_super_admin=True
-            )
+            ).distinct()
             # .exclude(actor=user)
             .order_by("-id")[:LIMIT]
         )
@@ -376,6 +376,6 @@ class Spy:
             return Footage.objects.filter(
                 portal=FootageConstants.on_admin_portal(),
                 communities__id__in = communities
-            ).order_by("-id")[:LIMIT]
+            ).distinct().order_by("-id")[:LIMIT]
         except Exception as e:
             Console.log("Could not fetch footages for community admin", e)

--- a/src/_main_/utils/footage/spy.py
+++ b/src/_main_/utils/footage/spy.py
@@ -18,28 +18,6 @@ class Spy:
     def __init__(self) -> None:
         pass
 
-    @staticmethod
-    def okay_to_record_sign_in_footage(**kwargs): 
-        # Context: Looks like our portals typically has to hit the auth.login route at least twice during login ( in less than 1 minute interval)
-        # And that results in recording double footage of the same sign in activity... So 
-        # Here, we are going to check the current datetime against the last signin activity that was recorded for a user 
-        # If the time interval is bigger than a minute, then return true ( Meaning: its okay to record the footage)
-        one_minute = 60  
-        now = datetime.now(timezone.utc)
-        user = kwargs.get("user", None) 
-        
-        last_sign_in = Footage.objects.filter(actor = user, activity_type = FootageConstants.sign_in()).order_by("-id").first() 
-        if not last_sign_in: 
-            return True 
-
-        diff = now - last_sign_in.created_at
-        diff = diff.total_seconds()
-        
-        if diff > one_minute : 
-            return True 
-        return False
-
-        
 
     @staticmethod
     def create_footage(**kwargs):

--- a/src/api/handlers/action.py
+++ b/src/api/handlers/action.py
@@ -227,6 +227,7 @@ class ActionHandler(RouteHandler):
   @super_admins_only
   def super_admin_list(self, request): 
     context: Context = request.context
+    args: dict = context.args
     self.validator.expect("community_id", int, is_required=False)
     self.validator.expect("action_ids", list, is_required=False)
     args, err = self.validator.verify(args)

--- a/src/api/handlers/action.py
+++ b/src/api/handlers/action.py
@@ -213,6 +213,7 @@ class ActionHandler(RouteHandler):
     args: dict = context.args
 
     self.validator.expect("community_id", int, is_required=False)
+    self.validator.expect("action_ids", list, is_required=False)
     args, err = self.validator.verify(args)
     if err:
       return err
@@ -226,7 +227,12 @@ class ActionHandler(RouteHandler):
   @super_admins_only
   def super_admin_list(self, request): 
     context: Context = request.context
-    actions, err = self.service.list_actions_for_super_admin(context)
+    self.validator.expect("community_id", int, is_required=False)
+    self.validator.expect("action_ids", list, is_required=False)
+    args, err = self.validator.verify(args)
+    if err:
+      return err
+    actions, err = self.service.list_actions_for_super_admin(context,args)
     if err:
       return err
     return MassenergizeResponse(data=actions)

--- a/src/api/handlers/community.py
+++ b/src/api/handlers/community.py
@@ -221,7 +221,7 @@ class CommunityHandler(RouteHandler):
     return MassenergizeResponse(data=communities)
 
   @admins_only
-  def community_admin_list(self, request):
+  def community_admin_list(self, request):  
     context: Context  = request.context
     #args = context.get_request_body()
     communities, err = self.service.list_communities_for_community_admin(context)

--- a/src/api/handlers/summary.py
+++ b/src/api/handlers/summary.py
@@ -33,6 +33,7 @@ class SummaryHandler(RouteHandler):
     self.validator.expect("time_range", str, is_required=False) 
     self.validator.expect("start_time", str, is_required=False) 
     self.validator.expect("end_time", str, is_required=False) 
+    self.validator.expect("communities", "str_list", is_required=False) 
     args, err = self.validator.verify(args, strict=True)
     if err:
       return err

--- a/src/api/handlers/summary.py
+++ b/src/api/handlers/summary.py
@@ -17,8 +17,8 @@ class SummaryHandler(RouteHandler):
     self.registerRoutes()
 
   def registerRoutes(self):
-    self.add("/summary.next.steps.forAdmins", self.next_steps_for_admins)
     #admin routes
+    self.add("/summary.next.steps.forAdmins", self.next_steps_for_admins)
     self.add("/summary.listForCommunityAdmin", self.community_admin_summary)
     self.add("/summary.listForSuperAdmin", self.super_admin_summary)
 

--- a/src/api/handlers/summary.py
+++ b/src/api/handlers/summary.py
@@ -19,14 +19,33 @@ class SummaryHandler(RouteHandler):
   def registerRoutes(self):
     #admin routes
     self.add("/summary.next.steps.forAdmins", self.next_steps_for_admins)
+    self.add("/summary.get.engagements", self.fetch_user_engagements_for_admins)
     self.add("/summary.listForCommunityAdmin", self.community_admin_summary)
     self.add("/summary.listForSuperAdmin", self.super_admin_summary)
 
-  # @admins_only
+
+  
+  def fetch_user_engagements_for_admins(self, request): 
+    context: Context = request.context
+    args: dict = context.args
+    self.validator.expect("is_community_admin", bool, is_required=False) # For manual testing
+    self.validator.expect("email", str, is_required=False) # For manual testing
+    self.validator.expect("time_range", str, is_required=False) 
+    self.validator.expect("start_time", str, is_required=False) 
+    self.validator.expect("end_time", str, is_required=False) 
+    args, err = self.validator.verify(args, strict=True)
+    if err:
+      return err
+
+    content, err = self.service.fetch_user_engagements_for_admins(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=content)
+
+  # @admins_only  UNCOMMENT THIS BEFORE PR(BPR)
   def next_steps_for_admins(self, request): 
     context: Context = request.context
     args: dict = context.args
-    # community_id = args.pop("community_id", None)
     self.validator.expect("is_community_admin", bool, is_required=False) # For manual testing
     self.validator.expect("email", str, is_required=False) # For manual testing
     args, err = self.validator.verify(args, strict=True)

--- a/src/api/handlers/summary.py
+++ b/src/api/handlers/summary.py
@@ -24,7 +24,7 @@ class SummaryHandler(RouteHandler):
     self.add("/summary.listForSuperAdmin", self.super_admin_summary)
 
 
-  
+  @admins_only 
   def fetch_user_engagements_for_admins(self, request): 
     context: Context = request.context
     args: dict = context.args
@@ -43,7 +43,7 @@ class SummaryHandler(RouteHandler):
       return err
     return MassenergizeResponse(data=content)
 
-  # @admins_only  UNCOMMENT THIS BEFORE PR(BPR)
+  @admins_only  
   def next_steps_for_admins(self, request): 
     context: Context = request.context
     args: dict = context.args

--- a/src/api/services/action.py
+++ b/src/api/services/action.py
@@ -118,8 +118,8 @@ class ActionService:
     return serialize_all(actions), None
 
 
-  def list_actions_for_super_admin(self, context: Context) -> Tuple[list, MassEnergizeAPIError]:
-    actions, err = self.store.list_actions_for_super_admin(context)
+  def list_actions_for_super_admin(self, context: Context,args) -> Tuple[list, MassEnergizeAPIError]:
+    actions, err = self.store.list_actions_for_super_admin(context,args)
     if err:
       return None, err
     return serialize_all(actions), None

--- a/src/api/services/auth.py
+++ b/src/api/services/auth.py
@@ -33,6 +33,7 @@ class AuthService:
     try:
       args = context.args or {}
       firebase_id_token = args.get('idToken', None)
+      noFootage = args.get('noFootage',None)
       if firebase_id_token:
         decoded_token = auth.verify_id_token(firebase_id_token)
         user_email = decoded_token.get("email")
@@ -62,12 +63,10 @@ class AuthService:
           algorithm='HS256'
         ).decode('utf-8')
         #---------------------------------------------------------
-        its_safe_to_record = Spy.okay_to_record_sign_in_footage(user = user)
-        if context.is_admin_site and its_safe_to_record:
-          if its_safe_to_record:
-            Spy.create_sign_in_footage(actor = user ,context = context, type = FootageConstants.sign_in())
-        else:
-          if its_safe_to_record:
+        if  noFootage == "false": 
+          if context.is_admin_site:
+             Spy.create_sign_in_footage(actor = user ,context = context, type = FootageConstants.sign_in())
+          else: 
             where_user_signed_in_from = Community.objects.filter(subdomain = context.community)
             Spy.create_sign_in_footage( communities = where_user_signed_in_from, actor = user, context = context, portal=FootageConstants.on_user_portal(), type = FootageConstants.sign_in())
         #---------------------------------------------------------

--- a/src/api/services/auth.py
+++ b/src/api/services/auth.py
@@ -33,7 +33,7 @@ class AuthService:
     try:
       args = context.args or {}
       firebase_id_token = args.get('idToken', None)
-      noFootage = args.get('noFootage',None)
+      noFootage = args.get('noFootage',"false") # Why this? Well login is used as verification in more than one scenario, so this is a way to know when user is actually signing in (1st time) -- so we can capture the footage only once.
       if firebase_id_token:
         decoded_token = auth.verify_id_token(firebase_id_token)
         user_email = decoded_token.get("email")

--- a/src/api/services/auth.py
+++ b/src/api/services/auth.py
@@ -64,6 +64,8 @@ class AuthService:
         #---------------------------------------------------------
         if context.is_admin_site:
           Spy.create_sign_in_footage(actor = user ,context = context, type = FootageConstants.sign_in())
+        else:
+          Spy.create_sign_in_footage(actor = user ,context = context, portal=FootageConstants.on_user_portal(), type = FootageConstants.sign_in())
         #---------------------------------------------------------
         return serialize(user, full=True), str(massenergize_jwt_token), None
 

--- a/src/api/services/community.py
+++ b/src/api/services/community.py
@@ -78,7 +78,7 @@ class CommunityService:
     communities, err = self.store.list_communities_for_community_admin(context)
     if err:
       return None, err
-    return serialize_all(communities), None
+    return serialize_all(communities, False, medium=True), None
 
 
   def list_communities_for_super_admin(self, context) -> Tuple[list, MassEnergizeAPIError]:

--- a/src/api/services/community.py
+++ b/src/api/services/community.py
@@ -85,7 +85,7 @@ class CommunityService:
     communities, err = self.store.list_communities_for_super_admin(context)
     if err:
       return None, err
-    return serialize_all(communities), None
+    return serialize_all(communities, False, medium=True), None
 
   def add_custom_website(self, context, args) -> Tuple[list, MassEnergizeAPIError]:
     communities, err = self.store.add_custom_website(context, args)

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -30,6 +30,7 @@ class SummaryService:
         teams = content.get("teams", [])
         done_int = content.get("done_interactions", [])
         todo_int = content.get("todo_interactions", [])
+        sign_ins = content.get("user_sign_ins",0)
 
         content = {
             "testimonials": {"count": len(testimonials), "data": list(testimonials)},
@@ -38,6 +39,7 @@ class SummaryService:
             "team_messages": {"count": len(team_messages), "data": list(team_messages)},
             "done_interactions": {"count": len(done_int), "data": list(done_int)},
             "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
+            "sign_ins": { "count": sign_ins, "data":[]},
             "users": {
                 "count": len(users),
                 "description": f"All new users since last visit - {last_visit.created_at}",

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -14,6 +14,25 @@ class SummaryService:
     def __init__(self):
         self.store = SummaryStore()
 
+    def fetch_user_engagements_for_admins(
+        self, context, args
+    ) -> Tuple[dict, MassEnergizeAPIError]:
+        content, err = self.store.fetch_user_engagements_for_admins(context, args)
+
+        if err:
+            return None, err
+      
+        done_int = content.get("done_interactions", [])
+        todo_int = content.get("todo_interactions", [])
+        sign_ins = content.get("user_sign_ins", [])
+
+        content = {
+            "done_interactions": {"count": len(done_int), "data": list(done_int)},
+            "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
+            "sign_ins": {"count": len(sign_ins), "data": list(sign_ins)},
+        }
+        return content, None
+
     def next_steps_for_admins(
         self, context, args
     ) -> Tuple[tuple, MassEnergizeAPIError]:
@@ -30,7 +49,7 @@ class SummaryService:
         teams = content.get("teams", [])
         done_int = content.get("done_interactions", [])
         todo_int = content.get("todo_interactions", [])
-        sign_ins = content.get("user_sign_ins",0)
+        sign_ins = content.get("user_sign_ins", [])
 
         content = {
             "testimonials": {"count": len(testimonials), "data": list(testimonials)},
@@ -39,7 +58,7 @@ class SummaryService:
             "team_messages": {"count": len(team_messages), "data": list(team_messages)},
             "done_interactions": {"count": len(done_int), "data": list(done_int)},
             "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
-            "sign_ins": { "count": len(sign_ins), "data":list(sign_ins)},
+            "sign_ins": {"count": len(sign_ins), "data": list(sign_ins)},
             "users": {
                 "count": len(users),
                 "description": f"All new users since last visit - {last_visit.created_at}",

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -39,7 +39,7 @@ class SummaryService:
             "team_messages": {"count": len(team_messages), "data": list(team_messages)},
             "done_interactions": {"count": len(done_int), "data": list(done_int)},
             "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
-            "sign_ins": { "count": sign_ins, "data":[]},
+            "sign_ins": { "count": len(sign_ins), "data":list(sign_ins)},
             "users": {
                 "count": len(users),
                 "description": f"All new users since last visit - {last_visit.created_at}",

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -27,9 +27,9 @@ class SummaryService:
         sign_ins = content.get("user_sign_ins", [])
 
         content = {
-            "done_interactions": {"count": len(done_int), "data": list(done_int)},
-            "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
-            "sign_ins": {"count": len(sign_ins), "data": list(sign_ins)},
+            "done_interactions": {"count": len(done_int), "data": list(set(done_int))},
+            "todo_interactions": {"count": len(todo_int), "data": list(set(todo_int))},
+            "sign_ins": {"count": len(sign_ins), "data": list(set(sign_ins))},
         }
         return content, None
 
@@ -47,22 +47,22 @@ class SummaryService:
         team_messages = content.get("team_messages", [])
         users = content.get("users", [])
         teams = content.get("teams", [])
-        done_int = content.get("done_interactions", [])
-        todo_int = content.get("todo_interactions", [])
-        sign_ins = content.get("user_sign_ins", [])
+        # done_int = content.get("done_interactions", [])
+        # todo_int = content.get("todo_interactions", [])
+        # sign_ins = content.get("user_sign_ins", [])
 
         content = {
-            "testimonials": {"count": len(testimonials), "data": list(testimonials)},
-            "teams": {"count": len(teams), "data": list(teams)},
-            "messages": {"count": len(messages), "data": list(messages)},
-            "team_messages": {"count": len(team_messages), "data": list(team_messages)},
-            "done_interactions": {"count": len(done_int), "data": list(done_int)},
-            "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
-            "sign_ins": {"count": len(sign_ins), "data": list(sign_ins)},
+            "testimonials": {"count": len(testimonials), "data": list(set(testimonials))},
+            "teams": {"count": len(teams), "data": list(set(teams))},
+            "messages": {"count": len(messages), "data": list(set(messages))},
+            "team_messages": {"count": len(team_messages), "data": list(set(team_messages))},
+            # "done_interactions": {"count": len(done_int), "data": list(done_int)},
+            # "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
+            # "sign_ins": {"count": len(sign_ins), "data": list(sign_ins)},
             "users": {
                 "count": len(users),
                 "description": f"All new users since last visit - {last_visit.created_at}",
-                "data": list(users),
+                "data": list(set(users)),
                 "last_visit": serialize(last_visit),
             },
         }

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -61,7 +61,7 @@ class SummaryService:
             # "sign_ins": {"count": len(sign_ins), "data": list(sign_ins)},
             "users": {
                 "count": len(users),
-                "description": f"All new users since last visit - {last_visit.created_at}",
+                "description": f"All new users since last visit - {last_visit.created_at if last_visit else '...'}",
                 "data": list(set(users)),
                 "last_visit": serialize(last_visit),
             },

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -28,17 +28,16 @@ class SummaryService:
         team_messages = content.get("team_messages", [])
         users = content.get("users", [])
         teams = content.get("teams", [])
-
-        # testimonials = serialize_all(testimonials)
-        # messages = serialize_all(messages)
-        # users = serialize_all(users)
-        # teams = serialize_all(teams)
+        done_int = content.get("done_interactions", [])
+        todo_int = content.get("todo_interations", [])
 
         content = {
             "testimonials": {"count": len(testimonials), "data": list(testimonials)},
             "teams": {"count": len(teams), "data": list(teams)},
             "messages": {"count": len(messages), "data": list(messages)},
             "team_messages": {"count": len(team_messages), "data": list(team_messages)},
+            "done_interactions": {"count": len(done_int), "data": list(done_int)},
+            "todo_interactions": {"count": len(todo_int), "data": list(todo_int)},
             "users": {
                 "count": len(users),
                 "description": f"All new users since last visit - {last_visit.created_at}",

--- a/src/api/services/summary.py
+++ b/src/api/services/summary.py
@@ -29,7 +29,7 @@ class SummaryService:
         users = content.get("users", [])
         teams = content.get("teams", [])
         done_int = content.get("done_interactions", [])
-        todo_int = content.get("todo_interations", [])
+        todo_int = content.get("todo_interactions", [])
 
         content = {
             "testimonials": {"count": len(testimonials), "data": list(testimonials)},

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -100,11 +100,9 @@ class SummaryStore:
                 created_at__gt=last_visit.created_at, communities__in=communities, is_deleted=False
             )
 
-        print("comms need to be here", communities)
         # Find all interactions users have had with any actions that belong to any of the communities a cadmin manages
-        todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit, is_deleted=False)
-        done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit, is_deleted=False)
-
+        todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
+        done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
         return {
             "users": users,
             "testimonials": testimonials,

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -71,11 +71,13 @@ class SummaryStore:
         elif time_range == LAST_MONTH:
             start_time = today - datetime.timedelta(days=31)
             end_time = today
-        # else: # dealing with custom date and time
-        #     start_time = datetime.datetime.strptime(start_time,"%Y-%M-%D %H:%M")
-        #     end_time = datetime.datetime.strptime(end_time,"%Y-%M-%D %H:%M")
-        #     # start_time = pytz.utc.localize(start_time)
-        #     # end_time = pytz.utc.localize(end_time)
+        else: # dealing with custom date and time
+            _format = "%Y-%m-%dT%H:%M:%SZ"
+            start_time = datetime.datetime.strptime(start_time,_format)
+            end_time = datetime.datetime.strptime(end_time,_format)
+            start_time = pytz.utc.localize(start_time)
+            end_time = pytz.utc.localize(end_time)  
+            
         # ------------------------------------------------------
 
         print("THIS IS THE DATE", start_time, end_time, communities) # remove before pR (BPR)

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -104,7 +104,7 @@ class SummaryStore:
         todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
         done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
         
-        user_sign_ins = Footage.objects.filter( communities__in = communities, portal = FootageConstants.on_user_portal(), activity_type = FootageConstants.sign_in(),created_at__gte = last_visit.created_at).count()
+        user_sign_ins = Footage.objects.values_list("actor__email", flat=True).filter( communities__in = communities, portal = FootageConstants.on_user_portal(), activity_type = FootageConstants.sign_in(),created_at__gte = last_visit.created_at)
         
         return {
             "users": users,
@@ -165,7 +165,7 @@ class SummaryStore:
         todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" , updated_at__gte=last_visit.created_at, is_deleted=False)
         done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE",  updated_at__gte=last_visit.created_at, is_deleted=False)
        
-        user_sign_ins = Footage.objects.filter( portal = FootageConstants.on_user_portal(), activity_type = FootageConstants.sign_in(),created_at__gte = last_visit.created_at).count()
+        user_sign_ins = Footage.objects.values_list("actor__email", flat=True).filter( portal = FootageConstants.on_user_portal(), activity_type = FootageConstants.sign_in(),created_at__gte = last_visit.created_at)
        
 
         return {

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -80,7 +80,6 @@ class SummaryStore:
             
         # ------------------------------------------------------
 
-        print("THIS IS THE DATE", start_time, end_time, communities) # remove before pR (BPR)
         if is_community_admin or (is_super_admin and not wants_all_communities):
             sign_in_query = Q(
                 communities__in=communities,
@@ -220,48 +219,18 @@ class SummaryStore:
             .order_by("-created_at")
             .first()
         )
-        print("Found Last Visit", last_visit)  # REMOVE BEFORE PR(BPR)
         if last_visit:
             users = UserProfile.objects.values_list("email", flat=True).filter(
                 created_at__gt=last_visit.created_at,
                 communities__in=communities,
                 is_deleted=False,
             )
-
-        # # Find all interactions users have had with any actions that belong to any of the communities a cadmin manages
-        # todo_interactions = UserActionRel.objects.values_list(
-        #     "action__id", flat=True
-        # ).filter(
-        #     status="TODO",
-        #     action__community__in=communities,
-        #     updated_at__gte=last_visit.created_at,
-        #     is_deleted=False,
-        # )
-        # done_interactions = UserActionRel.objects.values_list(
-        #     "action__id", flat=True
-        # ).filter(
-        #     status="DONE",
-        #     action__community__in=communities,
-        #     updated_at__gte=last_visit.created_at,
-        #     is_deleted=False,
-        # )
-
-        # user_sign_ins = Footage.objects.values_list("actor__email", flat=True).filter(
-        #     communities__in=communities,
-        #     portal=FootageConstants.on_user_portal(),
-        #     activity_type=FootageConstants.sign_in(),
-        #     created_at__gte=last_visit.created_at,
-        # )
-
         return {
             "users": users,
             "testimonials": testimonials,
             "messages": messages,
             "team_messages": team_messages,
             "teams": teams,
-            # "todo_interactions": todo_interactions,
-            # "done_interactions": done_interactions,
-            # "user_sign_ins": user_sign_ins,
             "last_visit": last_visit,
         }, None
 
@@ -302,25 +271,12 @@ class SummaryStore:
             .order_by("-created_at")
             .first()
         )
-        print(
-            "Found Last Visit", last_visit, last_visit.created_at
-        )  # REMOVE BEFORE PR(BPR)
+       
         if last_visit:
             users = UserProfile.objects.values_list("id", flat=True).filter(
                 created_at__gt=today, is_deleted=False
             )
-        # todo_interactions = UserActionRel.objects.values_list(
-        #     "action__id", flat=True
-        # ).filter(status="TODO", updated_at__gte=last_visit.created_at, is_deleted=False)
-        # done_interactions = UserActionRel.objects.values_list(
-        #     "action__id", flat=True
-        # ).filter(status="DONE", updated_at__gte=last_visit.created_at, is_deleted=False)
-
-        # user_sign_ins = Footage.objects.values_list("actor__email", flat=True).filter(
-        #     portal=FootageConstants.on_user_portal(),
-        #     activity_type=FootageConstants.sign_in(),
-        #     created_at__gte=last_visit.created_at,
-        # )
+      
 
         return {
             "users": users,
@@ -328,9 +284,6 @@ class SummaryStore:
             "messages": messages,
             "team_messages": team_messages,
             "teams": teams,
-            # "todo_interactions": todo_interactions,
-            # "done_interactions": done_interactions,
-            # "user_sign_ins": user_sign_ins,
             "last_visit": last_visit,
         }, None
 

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -158,8 +158,8 @@ class SummaryStore:
             users = UserProfile.objects.values_list("id", flat=True).filter(
                 created_at__gt=today, is_deleted=False
             )
-        todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
-        done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
+        todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" , updated_at__gte=last_visit.created_at, is_deleted=False)
+        done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE",  updated_at__gte=last_visit.created_at, is_deleted=False)
        
 
         return {

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -61,7 +61,6 @@ class SummaryStore:
         # ------------------------------------------------------
         if time_range == LAST_VISIT:
             start_time = self.get_admins_last_visit(email=email)
-            start_time = pytz.utc.localize(start_time)
             end_time = today
 
         elif time_range == LAST_WEEK:
@@ -169,7 +168,7 @@ class SummaryStore:
             .order_by("-created_at")
             .first()
         )
-        return last_visit
+        return last_visit.created_at
 
     def next_steps_for_community_admins(self, context: Context, args):
 

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -80,7 +80,7 @@ class SummaryStore:
             end_time = today
         # ------------------------------------------------------
 
-        print("THIS IS THE DATE", start_time, end_time, communities)
+        print("THIS IS THE DATE", start_time, end_time, communities) # remove before pR (BPR)
         if is_community_admin:
             sign_in_query = Q(
                 communities__in=communities,

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -103,6 +103,9 @@ class SummaryStore:
         # Find all interactions users have had with any actions that belong to any of the communities a cadmin manages
         todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
         done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
+        
+        user_sign_ins = Footage.objects.filter( communities__in = communities, portal = FootageConstants.on_user_portal(), activity_type = FootageConstants.sign_in(),created_at__gte = last_visit.created_at).count()
+        
         return {
             "users": users,
             "testimonials": testimonials,
@@ -111,6 +114,7 @@ class SummaryStore:
             "teams": teams,
             "todo_interactions":todo_interactions, 
             "done_interactions": done_interactions,
+            "user_sign_ins":user_sign_ins,
             "last_visit": last_visit,
         }, None
 

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -158,6 +158,9 @@ class SummaryStore:
             users = UserProfile.objects.values_list("id", flat=True).filter(
                 created_at__gt=today, is_deleted=False
             )
+        todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
+        done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit.created_at, is_deleted=False)
+       
 
         return {
             "users": users,
@@ -165,6 +168,8 @@ class SummaryStore:
             "messages": messages,
             "team_messages": team_messages,
             "teams": teams,
+            "todo_interactions":todo_interactions, 
+            "done_interactions": done_interactions,
             "last_visit": last_visit,
         }, None
 

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -9,6 +9,7 @@ from database.models import (
     Testimonial,
     Event,
     Team,
+    UserActionRel,
     UserProfile,
 )
 from _main_.utils.massenergize_errors import (
@@ -99,12 +100,19 @@ class SummaryStore:
                 created_at__gt=last_visit.created_at, communities__in=communities, is_deleted=False
             )
 
+        print("comms need to be here", communities)
+        # Find all interactions users have had with any actions that belong to any of the communities a cadmin manages
+        todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" ,action__community__in=communities, updated_at__gte=last_visit, is_deleted=False)
+        done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE", action__community__in=communities, updated_at__gte=last_visit, is_deleted=False)
+
         return {
             "users": users,
             "testimonials": testimonials,
             "messages": messages,
             "team_messages": team_messages,
             "teams": teams,
+            "todo_interactions":todo_interactions, 
+            "done_interactions": done_interactions,
             "last_visit": last_visit,
         }, None
 

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -165,6 +165,8 @@ class SummaryStore:
         todo_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status ="TODO" , updated_at__gte=last_visit.created_at, is_deleted=False)
         done_interactions = UserActionRel.objects.values_list("action__id", flat=True).filter(status = "DONE",  updated_at__gte=last_visit.created_at, is_deleted=False)
        
+        user_sign_ins = Footage.objects.filter( portal = FootageConstants.on_user_portal(), activity_type = FootageConstants.sign_in(),created_at__gte = last_visit.created_at).count()
+       
 
         return {
             "users": users,
@@ -174,6 +176,7 @@ class SummaryStore:
             "teams": teams,
             "todo_interactions":todo_interactions, 
             "done_interactions": done_interactions,
+            "user_sign_ins":user_sign_ins,
             "last_visit": last_visit,
         }, None
 

--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -11,11 +11,17 @@ from database.models import (
     Action,
     Community,
     CommunityAdminGroup,
+    CommunityMember,
     Event,
     FeatureFlag,
+    Footage,
     HomePageSettings,
     Media,
+    Message,
+    RealEstateUnit,
+    Team,
     Testimonial,
+    UserActionRel,
     UserMediaUpload,
     UserProfile,
 )
@@ -25,6 +31,45 @@ from io import BytesIO
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
 RESET = "reset"
+
+
+def makeFootage(**kwargs):
+    communities = kwargs.pop("communities",None)    
+    f =  Footage.objects.create(**{**kwargs})
+    if communities: 
+        f.communities.set(communities)
+    return f
+
+
+def makeUserActionRel(**kwargs):
+    action = kwargs.get("action")
+    community = kwargs.pop("community", action.community)
+    house = RealEstateUnit.objects.create(
+        **{"name": str(time.time()) + "-house", "community": community}
+    )
+    return UserActionRel.objects.create(**{"real_estate_unit": house, **kwargs})
+
+
+def makeTeam(**kwargs):
+    name = kwargs.get("name", str(time.time()) + "-team")
+    community = kwargs.pop("community", None)
+    communities = kwargs.pop("communities", None)
+    team = Team.objects.create(
+        **{**kwargs, "primary_community": community, "name": name}
+    )
+    if communities:
+        team.set(communities)
+    return team
+
+
+def makeMessage(**kwargs):
+    user = kwargs.get("user")
+    name = kwargs.pop("name", user.full_name)
+    return Message.objects.create(**{**kwargs, "user_name": name})
+
+
+def makeMembership(**kwargs):
+    return CommunityMember.objects.create(**{**kwargs})
 
 
 def makeFlag(**kwargs):

--- a/src/api/tests/test_user_engagements.py
+++ b/src/api/tests/test_user_engagements.py
@@ -25,6 +25,20 @@ class TestUserEngagements(TestCase):
 
 
     def test_user_engagement_summary(self):
+        """
+            The idea, is to 
+            1. Create a few communities 
+            2. Create users(normal)  
+            3. Make one user an admin of a few of the communities
+            4. Then make some actions that belong to the cadmin's communities 
+            5. After, the remaining normal users should sign in to some communities 
+            6. Complete actions, 
+            7. And add some actions as to do. 
+            Criteria for success 
+            If the engagement route works as it should, it will only retrieve the sign in footages, 
+            actions that have been completed, and ones that have been added todo for only the communiities 
+            that the current admin manages
+        """
         client = Client()
         Console.header("Testing Admin User Engagements")
         users = []
@@ -113,6 +127,19 @@ class TestUserEngagements(TestCase):
         
 
     def test_admin_next_steps(self):
+        """
+            Idea 
+            1. Again, create a few users 
+            2. Create a few communities 
+            3. Make one of the users an admin of a few of the communities 
+            4. Create testimonials for various communities 
+            5. Create actions for various communities 
+            6. Create messages (that look they were sent by users)
+            Criteria for success 
+            if the route works as it should, it will retrieve all unanswered actions, tesitmonials, 
+            messages that are related to any of the communities that the cadmin manages
+
+        """
         client = Client()
         Console.header("Admin Next Steps")
         users = []

--- a/src/api/tests/test_user_engagements.py
+++ b/src/api/tests/test_user_engagements.py
@@ -147,10 +147,12 @@ class TestUserEngagements(TestCase):
         response = client.post(
             "/api/summary.next.steps.forAdmins"
         ).json().get("data",{})
-        Console.log("response again", response)
         testimonials = response.get("testimonials",{}).get("data",[])
         teams = response.get('teams',{}).get("data",[])
         messages = response.get('messages').get("data",[])
+        
         self.assertEquals(len(testimonials),3)
         self.assertEquals(len(teams),3)
         self.assertEquals(len(messages),2)
+
+        print("Items for admins to attend to checkout!")

--- a/src/api/tests/test_user_engagements.py
+++ b/src/api/tests/test_user_engagements.py
@@ -1,0 +1,156 @@
+from unittest import TestCase
+from django.test import Client
+from _main_.utils.footage.FootageConstants import FootageConstants
+from _main_.utils.utils import Console
+from api.tests.common import (
+    createUsers,
+    makeAction,
+    makeAdmin,
+    makeCommunity,
+    makeFootage,
+    makeMembership,
+    makeMessage,
+    makeTeam,
+    makeTestimonial,
+    makeUser,
+    makeUserActionRel,
+    signinAs,
+)
+
+
+class TestUserEngagements(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        Console.header("Testing Admin User Engagement & What  to Do Next")
+
+
+    def test_user_engagement_summary(self):
+        client = Client()
+        Console.header("Testing Admin User Engagements")
+        users = []
+        communities = []
+
+        for i in range(3):
+            user = makeUser(name=f"User Number - {i+1}")
+            users.append(user)
+        for i in range(3):
+            com = makeCommunity()
+            communities.append(com)
+
+        a1 = makeAction(community=communities[0])
+        a2 = makeAction(community=communities[0])
+        a3 = makeAction(community=communities[1])
+        a4 = makeAction(community=communities[1])
+        a5 = makeAction(community=communities[2])
+        
+        # 3 different users mark an action as todo, but only 2 actions are involved (so only 2 communities will be involved)
+        # Which should be the 2 community that the current signed in admin will be in charge of
+        d1 = makeUserActionRel(action=a1, user=users[0], status="DONE")
+        d2 = makeUserActionRel(action=a2, user=users[1], status="DONE")
+        d3 = makeUserActionRel(action=a1, user=users[2], status="DONE")
+
+        # 2 users mark actions as todo. 4 actions involved, But only 3 of the actions are created in the communities 
+        # that the currently signed in admin manages
+        td1 = makeUserActionRel(action=a1, user=users[0], status="TODO")
+        td2 = makeUserActionRel(action=a2, user=users[0], status="TODO")
+        td3 = makeUserActionRel(action=a4, user=users[1], status="TODO")
+        td4 = makeUserActionRel(action=a5, user=users[1], status="TODO")
+
+        # 4 sign in footages. Only 3 of them are stationed in the admin's communities
+        f1 = makeFootage(
+            actor=users[0],
+            communities=communities[1:2], 
+            activity_type=FootageConstants.sign_in(),
+            portal=FootageConstants.on_user_portal(),
+        )
+        f2 = makeFootage(
+            actor=users[1],
+            communities=communities[:1],
+            activity_type=FootageConstants.sign_in(),
+            portal=FootageConstants.on_user_portal(),
+        )
+        f3 = makeFootage(
+            actor=users[0],
+            communities=communities[1:],
+            activity_type=FootageConstants.sign_in(),
+            portal=FootageConstants.on_user_portal(),
+        )
+        f4 = makeFootage(
+            actor=users[2],
+            communities=communities[2:],
+            activity_type=FootageConstants.sign_in(),
+            portal=FootageConstants.on_user_portal(),
+        )
+
+
+        cadmin = makeAdmin(communities=communities[:2])
+        signinAs(client, cadmin)
+
+        response = client.post(
+            "/api/summary.get.engagements", {"time_range": "last-month"}
+        ).json().get("data",{})
+        
+        done = response.get("done_interactions",{}).get('data',[])
+        done_count = response.get("done_interactions",{}).get("count",0)
+        todos = response.get("todo_interactions",{}).get('data',[])
+        todo_count = response.get("todo_interactions",{}).get("count",0)
+        sign_ins = response.get("sign_ins",{}).get('data',[])
+        sign_in_count = response.get("sign_ins",{}).get("count",0)
+
+        self.assertEquals(done_count,3)
+        self.assertEquals(todo_count,3)
+        self.assertEquals(sign_in_count,3)
+       
+        self.assertTrue(a5.id not in todos)
+        self.assertTrue(a1.id  in done)
+        self.assertTrue(a2.id  in done)
+        print("Todo, Done, and Sign in engagements retrieved!")
+
+        self.assertTrue(users[0].email  in sign_ins)
+        self.assertTrue(users[1].email  in sign_ins)
+        self.assertTrue(users[2].email  not in sign_ins)
+        print("The right values were retrieved!")
+        
+
+    def test_admin_next_steps(self):
+        client = Client()
+        Console.header("Admin Next Steps")
+        users = []
+        communities = []
+        for i in range(3):
+            user = makeUser(name=f"User Number - {i+1}")
+            users.append(user)
+        for i in range(3):
+            com = makeCommunity()
+            communities.append(com)
+
+        cadmin = makeAdmin(communities = communities[:2])
+       
+        makeMembership(user = users[0], community = communities[0])
+        makeMembership(user = users[1], community = communities[1])
+
+        testimonial = makeTestimonial(user = users[0], community=communities[0])
+        testimonial2 = makeTestimonial(user = users[0], community=communities[0])
+        testimonial3 = makeTestimonial(user = users[1], community=communities[1])
+
+        m1 = makeMessage(user=users[0], community = communities[0])
+        m2 = makeMessage(user=users[1], community = communities[1])
+        m3 = makeMessage(user=users[1], community = communities[2])
+
+        t1 = makeTeam(community = communities[0])
+        t2 = makeTeam(community = communities[0])
+        t3 = makeTeam(community = communities[1])
+        t4 = makeTeam(community = communities[1], is_published=True)
+        t3 = makeTeam(community = communities[2])
+        signinAs(client, cadmin)
+
+        response = client.post(
+            "/api/summary.next.steps.forAdmins"
+        ).json().get("data",{})
+        Console.log("response again", response)
+        testimonials = response.get("testimonials",{}).get("data",[])
+        teams = response.get('teams',{}).get("data",[])
+        messages = response.get('messages').get("data",[])
+        self.assertEquals(len(testimonials),3)
+        self.assertEquals(len(teams),3)
+        self.assertEquals(len(messages),2)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -9,6 +9,7 @@ from _main_.utils.footage.FootageConstants import FootageConstants
 from database.utils.constants import *
 from database.utils.settings.admin_settings import AdminPortalSettings
 from database.utils.settings.user_settings import UserPortalSettings
+
 from .utils.common import (
     get_images_in_sequence,
     json_loader,
@@ -23,7 +24,28 @@ import uuid
 CHOICES = json_loader("./database/raw_data/other/databaseFieldChoices.json")
 ZIP_CODE_AND_STATES = json_loader("./database/raw_data/other/states.json")
 
+# -------------------------------------------------------------------------
 
+def get_enabled_flags(_self, users = False): # _self : CommunityObject or UserProfileObject
+    feature_flags = FeatureFlag.objects.all() # We get all available flags
+    feature_flags_json = []
+    for f in feature_flags: # Go over all the flags
+        specified = f.communities.all() if not users else f.users.all() # Then note down which communities each flag is enabled for
+        enabled = (
+            (f.audience == "EVERYONE")
+            or (  # FeatureFlagConstants.AUDIENCE["EVERYONE"]["key"]
+                f.audience == "SPECIFIC" and _self in specified
+            )
+            or (f.audience == "ALL_EXCEPT" and _self not in specified)
+        ) # Check if flag is enabled for the community
+        enabled = enabled and (
+            not f.expires_on
+            or f.expires_on > datetime.datetime.now(f.expires_on.tzinfo)
+        ) 
+        if enabled:
+            feature_flags_json.append(f.simple_json())  # Then if the flag hasnt expired, note down the flag
+    return feature_flags_json
+# -------------------------------------------------------------------------
 class Location(models.Model):
     """
     A class used to represent a geographical region.  It could be a complete and
@@ -458,6 +480,11 @@ class Community(models.Model):
         res["favicon"] = get_json_if_not_none(self.favicon)
         return res
 
+    def medium_json(self): 
+        res = self.simple_json() 
+        res["feature_flags"] =  get_enabled_flags(self)
+        return res
+
     def full_json(self):
         admin_group: CommunityAdminGroup = CommunityAdminGroup.objects.filter(
             community__id=self.pk
@@ -525,23 +552,23 @@ class Community(models.Model):
             locations += l
 
         # Feature flags can either enable features for specific communities, or disable them
-        feature_flags = FeatureFlag.objects.all()
-        feature_flags_json = []
-        for f in feature_flags:
-            specified_communities = f.communities.all()
-            enabled = (
-                (f.audience == "EVERYONE")
-                or (  # FeatureFlagConstants.AUDIENCE["EVERYONE"]["key"]
-                    f.audience == "SPECIFIC" and self in specified_communities
-                )
-                or (f.audience == "ALL_EXCEPT" and self not in specified_communities)
-            )
-            enabled = enabled and (
-                not f.expires_on
-                or f.expires_on > datetime.datetime.now(f.expires_on.tzinfo)
-            )
-            if enabled:
-                feature_flags_json.append(f.simple_json())
+        # feature_flags = FeatureFlag.objects.all()
+        # feature_flags_json = []
+        # for f in feature_flags:
+        #     specified_communities = f.communities.all()
+        #     enabled = (
+        #         (f.audience == "EVERYONE")
+        #         or (  # FeatureFlagConstants.AUDIENCE["EVERYONE"]["key"]
+        #             f.audience == "SPECIFIC" and self in specified_communities
+        #         )
+        #         or (f.audience == "ALL_EXCEPT" and self not in specified_communities)
+        #     )
+        #     enabled = enabled and (
+        #         not f.expires_on
+        #         or f.expires_on > datetime.datetime.now(f.expires_on.tzinfo)
+        #     )
+        #     if enabled:
+        #         feature_flags_json.append(f.simple_json())
 
         return {
             "id": self.id,
@@ -566,7 +593,7 @@ class Community(models.Model):
             "admins": admins,
             "geography_type": self.geography_type,
             "locations": locations,
-            "feature_flags": feature_flags_json,
+            "feature_flags": get_enabled_flags(self),
         }
 
     class Meta:
@@ -868,24 +895,24 @@ class UserProfile(models.Model):
         #     for cm in CommunityMember.objects.filter(user=self, is_admin=True)
         # ]
 
-        # Feature flags can either enable features for specific users, or disable them for specific users
-        feature_flags = FeatureFlag.objects.all()
-        feature_flags_json = []
-        for f in feature_flags:
-            specified_users = f.users.all()
-            enabled = (
-                (f.user_audience == "EVERYONE")
-                or (  # FeatureFlagConstants.AUDIENCE["EVERYONE"]["key"]
-                    f.user_audience == "SPECIFIC" and self in specified_users
-                )
-                or (f.user_audience == "ALL_EXCEPT" and self not in specified_users)
-            )
-            enabled = enabled and (
-                not f.expires_on
-                or f.expires_on > datetime.datetime.now(f.expires_on.tzinfo)
-            )
-            if enabled:
-                feature_flags_json.append(f.simple_json())
+        # # Feature flags can either enable features for specific users, or disable them for specific users
+        # feature_flags = FeatureFlag.objects.all()
+        # feature_flags_json = []
+        # for f in feature_flags:
+        #     specified_users = f.users.all()
+        #     enabled = (
+        #         (f.user_audience == "EVERYONE")
+        #         or (  # FeatureFlagConstants.AUDIENCE["EVERYONE"]["key"]
+        #             f.user_audience == "SPECIFIC" and self in specified_users
+        #         )
+        #         or (f.user_audience == "ALL_EXCEPT" and self not in specified_users)
+        #     )
+        #     enabled = enabled and (
+        #         not f.expires_on
+        #         or f.expires_on > datetime.datetime.now(f.expires_on.tzinfo)
+        #     )
+        #     if enabled:
+        #         feature_flags_json.append(f.simple_json())
 
         data = model_to_dict(
             self, exclude=["real_estate_units", "communities", "roles"]
@@ -920,7 +947,7 @@ class UserProfile(models.Model):
             "user_portal_settings": user_portal_settings,
             "admin_portal_settings": admin_portal_settings,
         }
-        data["feature_flags"] = feature_flags_json
+        data["feature_flags"] = get_enabled_flags(self, True)
 
         return data
 

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1655,7 +1655,7 @@ class Action(models.Model):
     is_approved = models.BooleanField(default=False, blank=True)
 
     def __str__(self):
-        return self.title
+        return f"{str(self.id)} - {self.title}"
 
     def info(self):
         return model_to_dict(self, ["id", "title"])
@@ -1703,7 +1703,7 @@ class Action(models.Model):
         return data
 
     class Meta:
-        ordering = ["rank", "title"]
+        ordering = ["-id","rank", "title"]
         db_table = "actions"
         # had required this unique, now enforced in code
         # unique_together = [["title", "community"]]
@@ -2157,10 +2157,10 @@ class UserActionRel(models.Model):
         return res
 
     def __str__(self):
-        return "%s | %s | (%s)" % (self.user, self.status, self.action)
+        return "%s - %s | %s | (%s)" % (str(self.id), self.user, self.status, self.action)
 
     class Meta:
-        ordering = ("status", "user", "action")
+        ordering = ("-id","status", "user", "action")
         unique_together = [["user", "action", "real_estate_unit"]]
 
 

--- a/src/database/utils/common.py
+++ b/src/database/utils/common.py
@@ -12,6 +12,8 @@ from sentry_sdk import capture_message
 from _main_.utils.utils import Console
 
 
+
+
 def get_images_in_sequence(images,sequence): 
   if not sequence: return images  
   if not images: return []


### PR DESCRIPTION
### Related ticket: https://github.com/massenergize/frontend-admin/issues/696
## Works with Admin Frontend API : https://github.com/massenergize/frontend-admin/pull/845 

- [X] Introduced a new route `/summary.get.engagement` to summarise community engagements, and differentiated things admins need to from community engagements. It collects user sign in footages, number of actions completed, number of actions in user todolists for all users in an admin's communities, based on a given datetime range. 


See admin portal PR for Demo

### ⚠️  This PR is only manually tested. Automated tests will follow soon!
