### PR TITLE
Change: Prevent Cadmin from Deleting users with multiple communities

### DIFF
--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -129,6 +129,20 @@ def _update_action_data_totals(action, household, delta):
 
       d.save()
 
+def can_be_deleted(user, context):
+  if user.is_super_admin:
+    return False
+  if context.user_is_community_admin and  user.is_community_admin:
+    return False
+  
+  communityMembers = CommunityMember.objects.filter(user=user, is_deleted=False)
+  if len(communityMembers) > 1:
+    return False
+  
+  return True
+  
+
+
 
 class UserStore:
   def __init__(self):
@@ -190,7 +204,7 @@ class UserStore:
       return True
     
     return False
-
+  
 
   def _add_action_rel(self, context: Context, args, status):
     """
@@ -601,6 +615,10 @@ class UserStore:
       
       users = UserProfile.objects.filter(id=user_id)
       user = users.first()
+
+      if not can_be_deleted(user,context):
+        return None, CustomMassenergizeError("User can't be deleted")
+      
       # since we do not delete the record from the database but mark it as deleted, and the email needs to be unique,
       # modify the email address in case the person wants to create a profile again with that email. 
       # This allows us to tell exactly what happened in case we need to find out what happened to a users profile.


### PR DESCRIPTION
####  Summary / Highlights

#### Related to [Ticket 781](https://github.com/massenergize/frontend-admin/issues/781) 
Users who are members  of multiple communities will not be deleted by a Cadmin
#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
