### PR TITLE
full json return when homepage settings is updated

### DIFF
--- a/src/api/services/page_settings__home.py
+++ b/src/api/services/page_settings__home.py
@@ -43,7 +43,7 @@ class HomePageSettingsService:
     home_page_setting, err = self.store.update_home_page_setting(args)
     if err:
       return None, err
-    return serialize(home_page_setting), None
+    return serialize(home_page_setting, True), None
 
   def delete_home_page_setting(self, args) -> Tuple[dict, MassEnergizeAPIError]:
     home_page_setting, err = self.store.delete_home_page_setting(args)

--- a/src/api/store/page_settings__home.py
+++ b/src/api/store/page_settings__home.py
@@ -147,6 +147,7 @@ class HomePageSettingsStore:
 
       #now, update the other fields in one swing
       HomePageSettings.objects.filter(id=home_page_id).update(**args)
+      home_page_setting.refresh_from_db()
       return home_page_setting, None
     except Exception as e:
       capture_message(str(e), level="error")


### PR DESCRIPTION
### Works with Frontend PR: https://github.com/massenergize/frontend-admin/pull/959


Here, I am just sending out the full Json for homepage_settings.update response. Cos on the frontend, that full json, is needed to replace the cached version in redux after update