### PR TITLE
Bug Fix: Postmark footage Error

### DIFF
--- a/src/_main_/utils/constants.py
+++ b/src/_main_/utils/constants.py
@@ -2,6 +2,7 @@
 This file contains Global constants used throughout the codebase.
 """
 
+import os
 from _main_.settings import IS_PROD, IS_CANARY, IS_LOCAL, BASE_DIR
 from _main_.utils.utils import load_json
 
@@ -42,3 +43,8 @@ STATES = load_json(BASE_DIR + "/database/raw_data/other/states.json")
 ME_LOGO_PNG = "https://www.massenergize.org/wp-content/uploads/2021/07/cropped-me-logo-transp.png"
 
 DEFAULT_PAGINATION_LIMIT = 50
+
+
+ME_INBOUND_EMAIL_ADDRESS = (
+    "inbound@massenergize.org"if IS_PROD else os.environ.get('POSTMARK_DEFAULT_INBOUND_EMAIL') if IS_LOCAL else "inbound@massenergize.dev"
+)

--- a/src/_main_/utils/emailer/send_email.py
+++ b/src/_main_/utils/emailer/send_email.py
@@ -5,9 +5,11 @@ from sentry_sdk import capture_message
 import pystmark
 
 from _main_.settings import POSTMARK_EMAIL_SERVER_TOKEN, POSTMARK_DOWNLOAD_SERVER_TOKEN
+from _main_.utils.constants import ME_INBOUND_EMAIL_ADDRESS
 from _main_.utils.utils import is_test_mode
 
 FROM_EMAIL = 'no-reply@massenergize.org'
+
 
 def send_massenergize_email(subject, msg, to):
   if is_test_mode(): 
@@ -59,7 +61,8 @@ def send_massenergize_rich_email(subject, to, massenergize_email_type, content_v
     to=to,
     sender=from_email, 
     html=html_content, 
-    text=text_content
+    text=text_content,
+    reply_to=ME_INBOUND_EMAIL_ADDRESS,
   )
   response = pystmark.send(message, api_key=POSTMARK_EMAIL_SERVER_TOKEN)
 

--- a/src/api/services/admin.py
+++ b/src/api/services/admin.py
@@ -1,5 +1,5 @@
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, CustomMassenergizeError
-from _main_.utils.common import serialize, serialize_all
+from _main_.utils.common import serialize
 from _main_.utils.pagination import paginate
 from api.store.admin import AdminStore
 from _main_.utils.constants import ADMIN_URL_ROOT, COMMUNITY_URL_ROOT
@@ -112,8 +112,7 @@ class AdminService:
             "subject": message.title,
             "message_body": message.body,
         }
-        send_massenergize_rich_email(
-          subject, admin_email, 'contact_admin_email.html', content_variables)
+        send_massenergize_rich_email(subject, admin_email, 'contact_admin_email.html', content_variables)
 
         if IS_PROD or IS_CANARY:
           send_slack_message(

--- a/src/api/services/message.py
+++ b/src/api/services/message.py
@@ -33,14 +33,13 @@ class MessageService:
       if err:
         return None, err
       
-      from_email = message.user.email
       new_args = {
           "parent": message,
           'community_id': message.community.pk,
           'title': args.get('title'),
           'body': args.get('body'),
           'email': args.get('to'),
-          'from': from_email,
+          'from': args.get('from_email'),
         }
 
       reply, create_err = self.store.message_admin(context, new_args)

--- a/src/api/services/webhook.py
+++ b/src/api/services/webhook.py
@@ -78,9 +78,9 @@ class WebhookService:
   
   def process_inbound_webhook(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
     try:
-        
         reply = args.get("StrippedTextReply")
         text_body = args.get("TextBody")
+        from_email = args.get("From")
 
         splitted_body = text_body.strip().split("Here is a copy of the message:")
         if len(splitted_body) < 2: # will probably be a postmark test
@@ -94,7 +94,8 @@ class WebhookService:
             "title": f"Re: {subject}",
             "body": reply,
             "to": email, 
-            "message_id": db_msg_id
+            "message_id": db_msg_id,
+            "from_email": from_email
           })
 
           if err:

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -65,9 +65,11 @@ class MessageStore:
             body = args.pop("body", None)
             file = args.pop("uploaded_file", None)
             parent = args.pop("parent", None)
-            from_email = args.get("from")
-            from_user = get_user(from_email)
-            print(from_user)
+            sender_email = args.get("from") or context.user_email
+
+            sender, error = get_user(user_id=None,email=sender_email)
+            if error:
+                return None, error
 
             community, err = get_community(community_id, subdomain)
             if err:
@@ -81,7 +83,7 @@ class MessageStore:
                 parent=parent,
             )
             new_message.save()
-            user, err = get_user(context.user_id, email)
+            user, err = get_user(context.user_id, sender_email)
 
             if err:
                 return None, err
@@ -102,7 +104,7 @@ class MessageStore:
             new_message.save()
             # ----------------------------------------------------------------
             Spy.create_messaging_footage(
-                actor=from_user,
+                actor=sender,
                 messages=[new_message],
                 context=context,
                 type=FootageConstants.update(),


### PR DESCRIPTION
####  Summary / Highlights
This PR fixes the issue where the footage actor is null when admins reply to user messages from their email app. The issue occurs because the user_id and user_email fields in the API's context object are null since the user is not logged in. To solve the problem, we pass and use the sender email from the reply to get the associated user and use that user as the actor for the footage. This approach solves the bug by properly associating the actor with the footage, even when the user is not logged in.
