### PR TITLE
warning wont show in console anymore

### DIFF
--- a/src/socket_notifications/consumers/user_session_tracker_consumer.py
+++ b/src/socket_notifications/consumers/user_session_tracker_consumer.py
@@ -11,45 +11,51 @@ from api.utils.constants import WHEN_USER_AUTHENTICATED_SESSION_EXPIRES
 
 USER_SESSION_HAS_EXPIRED = "user_session_expired"
 CONNECTION_ESTABLISHED = "connection_established"
+WAIT_TIME = 600 # 10 Minutes
 
 class UserSessionTrackerConsumer(AsyncWebsocketConsumer):
 
     async def connect(self):
-        await self.accept() 
+        await self.accept()
         await self.send(text_data=json.dumps({
-            "type":CONNECTION_ESTABLISHED, 
-            "message":"Its safe, send gift!"
+            "type": CONNECTION_ESTABLISHED,
+            "message": "It's safe, send a gift!"
         }))
 
         await self.track()
-        
-    async def send_auth_notification(self): 
-        response = {"type":USER_SESSION_HAS_EXPIRED,"message":"User needs to sign in again..."}
+
+    async def send_auth_notification(self):
+        response = {"type": USER_SESSION_HAS_EXPIRED, "message": "User needs to sign in again..."}
         await self.send(json.dumps(response))
 
     async def track(self):
-        # return await super().receive(text_data, bytes_data)
         session = self.scope.get("session")
         expiration_in_session = session.get(WHEN_USER_AUTHENTICATED_SESSION_EXPIRES)
 
         # If there is ever a situation where the expiration time is not sent through by the frontend 
         # Send a message back to send (There on frontend, admins can be forced to sign in again, if the value is really somehow not available)
-        if not expiration_in_session: 
-            response = {"type":USER_SESSION_HAS_EXPIRED,"message":"Did not receive session expiration time..."}
+        if not expiration_in_session:
+            response = {"type": USER_SESSION_HAS_EXPIRED, "message": "Did not receive session expiration time..."}
             await self.send(json.dumps(response))
-            return 
-        in_seconds = expiration_in_session/1000
-        expiration_as_date = datetime.fromtimestamp(in_seconds,tz=pytz.UTC)
+            return
+
+        in_seconds = expiration_in_session / 1000
+        expiration_as_date = datetime.fromtimestamp(in_seconds, tz=pytz.UTC)
 
         # --- FOR TESTING, UNCOMMENT THIS PART FOR A SHORTER WAIT
         # expiration_as_date = datetime.now(tz=pytz.UTC) + timedelta(seconds=15)
 
-     
+        self.expiry_task = asyncio.create_task(self.check_expiry(expiration_as_date))
 
-        while True: 
+    async def check_expiry(self, expiration_as_date):
+        while True:
             current_date_and_time = datetime.now(tz=pytz.UTC)
-            if current_date_and_time > expiration_as_date: 
-                await self.send_auth_notification() 
-                break 
-            await asyncio.sleep(5) 
-    
+            if current_date_and_time > expiration_as_date:
+                await self.send_auth_notification()
+                break
+            await asyncio.sleep(WAIT_TIME) 
+
+    async def disconnect(self, close_code):
+        if hasattr(self, 'expiry_task'):
+            self.expiry_task.cancel()
+        await super().disconnect(close_code)


### PR DESCRIPTION

### Context 
So this error was kind of showing up every time the socket disconnected. 
`...channels/routing.py:71> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7fefdbd501f0>()]>> for connection <WebSocketProtocol client=['172.31.28.234', 29590] path=b'/ws/me-client/connect/'> took too long to shut down and was killed.`

I was able to trace it down to the async.sleep we were using. We were not cleaning up appropriately during disconnects. So in this PR, all async counts are being cleaned up on disconnects. So that warning should not be appearing anymore.


### Unrelated Changes 
I changed the thing loop  wait time from 5 seconds to 10 minutes. I mean we are not doing that much in that function for the 50-second-checks to amount to anything in compute power. But, in future when we have like 4million users, it might compound to a significant increase in computer power on the server 🤣 🤣 . So I changed it to a longer wait.