### PR TITLE
API Bugs  719 and 720

### DIFF
--- a/src/api/handlers/userprofile.py
+++ b/src/api/handlers/userprofile.py
@@ -4,7 +4,7 @@ from _main_.utils import context
 from _main_.utils.route_handler import RouteHandler
 from api.services.userprofile import UserService
 from _main_.utils.massenergize_response import MassenergizeResponse
-from _main_.utils.massenergize_errors import CustomMassenergizeError
+from _main_.utils.massenergize_errors import NotAuthorizedError
 from _main_.utils.context import Context
 from api.decorators import admins_only, super_admins_only, login_required
 from api.store.common import create_pdf_from_rich_text
@@ -177,14 +177,22 @@ class UserHandler(RouteHandler):
     def update(self, request):
         context: Context = request.context
         args: dict = context.args
+
+        args, err = (
+             self.validator.rename("user_id", "id")
+             .expect("id", str, is_required=False)
+             .verify(context.args)
+        )
+        if err:
+             return err
+
         # user info is now taken from context
-        # args, err = (
-        #     self.validator.rename("user_id", "id")
-        #     .expect("id", str, is_required=False)
-        #     .verify(context.args)
-        # )
-        # if err:
-        #     return err
+        # strip user_id, id out of args if not using
+        # validate that id passed in is 
+        id = args.pop('id', None)
+        if id and id != context.user_id:
+            return None, NotAuthorizedError()
+        
 
         user_info, err = self.service.update_user(context, args)
         if err:

--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -193,17 +193,19 @@ class ActionStore:
   def update_action(self, context: Context, args, user_submitted) -> Tuple[dict, MassEnergizeAPIError]:
     try:
       action_id = args.pop('action_id', None)
-      action = Action.objects.filter(id=action_id)
-      if not action:
+      actions = Action.objects.filter(id=action_id)
+      if not actions:
         return None, InvalidResourceError()
+      action = actions.first()
 
       # checks if requesting user is the testimonial creator, super admin or community admin else throw error
-      if str(action.first().user_id) != context.user_id and not context.user_is_super_admin and not context.user_is_community_admin:
+      if str(action.user_id) != context.user_id and not context.user_is_super_admin and not context.user_is_community_admin:
         return None, NotAuthorizedError()
       
       # check if user is community admin and is also an admin of the community that created the action
       if context.user_is_community_admin:
-        if not is_admin_of_community(context, action.first().community.id):
+        community = action.community
+        if community and not is_admin_of_community(context, community.id):
           return None, NotAuthorizedError()
 
       community_id = args.pop('community_id', None)
@@ -220,8 +222,7 @@ class ActionStore:
         args.pop("is_approved", None)
         args.pop("is_published", None)
 
-      action.update(**args)
-      action = action.first()
+      actions.update(**args)
 
       if image: #now, images will always come as an array of ids, or "reset" string 
         if user_submitted:

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -347,19 +347,23 @@ class EventStore:
     try:
       event_id = args.pop('event_id', None)
       events = Event.objects.filter(id=event_id)
+
       publicity_selections = args.pop("publicity_selections", [])
       shared_to = args.pop("shared_to", [])
 
       if not events:
         return None, InvalidResourceError()
+      event = events.first()
 
       # checks if requesting user is the testimonial creator, super admin or community admin else throw error
-      if str(events.first().user_id) != context.user_id and not context.user_is_super_admin and not context.user_is_community_admin:
+      if str(event.user_id) != context.user_id and not context.user_is_super_admin and not context.user_is_community_admin:
         return None, NotAuthorizedError()
       
-      # check if user is community admin and is also an admin of the community that created the action
+      # if no community selected previously (which happens when copying event), that is ok.
+      # Otherwise check if user is community admin and is also an admin of the community that created the action
       if context.user_is_community_admin:
-        if not is_admin_of_community(context, events.first().community.id):
+        community = event.community
+        if community and not is_admin_of_community(context, community.id):
           return None, NotAuthorizedError()
 
       image = args.pop('image', None)

--- a/src/api/store/vendor.py
+++ b/src/api/store/vendor.py
@@ -129,12 +129,13 @@ class VendorStore:
     
     try:
       vendor_id = args.pop('vendor_id', None)
-      vendor = Vendor.objects.filter(id=vendor_id)
-      if not vendor:
+      vendors = Vendor.objects.filter(id=vendor_id)
+      if not vendors:
         return None, InvalidResourceError()  
+      vendor = vendors.first()
 
       # checks if requesting user is the vendor creator, super admin or community admin else throw error
-      if str(vendor.first().user_id) != context.user_id and not context.user_is_super_admin and not context.user_is_community_admin:
+      if str(vendor.user_id) != context.user_id and not context.user_is_super_admin and not context.user_is_community_admin:
         return None, NotAuthorizedError()
 
       communities = args.pop('communities', [])
@@ -153,9 +154,7 @@ class VendorStore:
         args['location'] = None
       is_published = args.pop('is_published', None)
 
-
-      vendor.update(**args)
-      vendor = vendor.first()
+      vendors.update(**args)
       
       if communities:
         vendor.communities.set(communities)


### PR DESCRIPTION
####  Summary / Highlights
Fix two bugs which came in with the security API

719 - updating user profile, if user_id specfied
720 - copying events actions or testimonials and saving them