### PR TITLE
Filter bad words from username

### DIFF
--- a/src/api/handlers/userprofile.py
+++ b/src/api/handlers/userprofile.py
@@ -89,9 +89,9 @@ class UserHandler(RouteHandler):
         context: Context = request.context
         args: dict = context.args
 
-        data, err = self.service.validate_username(args["username"])
+        data, err = self.service.validate_username(args.get("username"))
         if err:
-            return err
+            return MassenergizeResponse(error=err)
         return MassenergizeResponse(data=data)
 
     def create(self, request):

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -179,11 +179,11 @@ class UserStore:
         is_bad_word = filter.blacklisted(username)
        
         if is_bad_word: 
-          return None ,"Your username may contain some profanity, please change"
+          return {'valid': False, 'suggested_username': None, "message":"Your username may contain some profanity, please change..."}, None
         
         # checks if username already exists
         if not UserProfile.objects.filter(preferred_name=username).exists():
-            return {'valid': True, 'suggested_username': username}, None
+            return {'valid': True, 'suggested_username': username, "message":"User already exists..."}, None
 
         # username exists, finds next available closest username
         usernames = list(UserProfile.objects.filter(preferred_name__istartswith=username).order_by('preferred_name').values_list("preferred_name", flat=True))

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -19,6 +19,7 @@ from _main_.utils.constants import ME_LOGO_PNG
 from api.utils.constants import GUEST_USER_EMAIL_TEMPLATE_ID, ME_SUPPORT_TEAM_EMAIL, MOU_SIGNED_ADMIN_RECEIPIENT, MOU_SIGNED_SUPPORT_TEAM_TEMPLATE, STANDARD_USER, INVITED_USER, GUEST_USER
 from _main_.utils.emailer.send_email import send_massenergize_email, send_massenergize_email_with_attachments
 from datetime import datetime
+from wordfilter import Wordfilter
 
 
 
@@ -170,10 +171,16 @@ class UserStore:
 
   def validate_username(self, username):
     # returns [is_valid, suggestion], error
+    filter = Wordfilter()
+    filter.addWords(["fuck","pussio"]) # These are not  in the general list that the plugin provides here https://github.com/dariusk/wordfilter/blob/master/lib/badwords.json
     try:    
         if (not username):
             return {'valid': False, 'suggested_username': None}, None
-
+        is_bad_word = filter.blacklisted(username)
+       
+        if is_bad_word: 
+          return None ,"Your username may contain some profanity, please change"
+        
         # checks if username already exists
         if not UserProfile.objects.filter(preferred_name=username).exists():
             return {'valid': True, 'suggested_username': username}, None

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -175,24 +175,21 @@ class UserStore:
     filter.addWords(["fuck","pussio"]) # These are not  in the general list that the plugin provides here https://github.com/dariusk/wordfilter/blob/master/lib/badwords.json
     try:    
         if (not username):
-            return {'valid': False, 'suggested_username': None}, None
+            return {'valid': False, "code":401, 'suggested_username': None}, None
         is_bad_word = filter.blacklisted(username)
        
         if is_bad_word: 
-          return {'valid': False, 'suggested_username': None, "message":"Your username may contain some profanity, please change..."}, None
+          return {'valid': False, 'suggested_username': None, "code":911, "message":"Your username may contain some profanity, please change..."}, None
         
-        # checks if username already exists
-        if not UserProfile.objects.filter(preferred_name=username).exists():
-            return {'valid': True, 'suggested_username': username, "message":"User already exists..."}, None
-
-        # username exists, finds next available closest username
-        usernames = list(UserProfile.objects.filter(preferred_name__istartswith=username).order_by('preferred_name').values_list("preferred_name", flat=True))
-
+        # (TODO: When there is time, this part downwards could be implemented better)
+        usernames = list(UserProfile.objects.filter(preferred_name__iexact=username).order_by('preferred_name').values_list("preferred_name", flat=True))
         if len(usernames) == 1:
             suggestion = username + "1"
-            return {'valid': False, 'suggested_username': suggestion}, None
-
-        # more than one username starting with the test username
+            return {'valid': False, "code":202,'suggested_username': suggestion}, None
+        elif len(usernames) == 0:  # The value is actually unique here so just return valid
+          return {'valid': True, "code":200,'suggested_username': username}, None
+       
+        # more than one username starting with the test username 
         suggestion = None
         for i in range(1, 999):
           test_username = username + str(i)
@@ -203,7 +200,7 @@ class UserStore:
         if not suggestion:
           return None, CustomMassenergizeError("No further usernames to suggest")
         else:
-          return {'valid': False, 'suggested_username': suggestion}, None
+          return {'valid': False, "code":202, 'suggested_username': suggestion}, None
         
     except Exception as e:
         return None, CustomMassenergizeError(e)

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -30,3 +30,4 @@ semver==2.13.0
 xhtml2pdf==0.2.9
 channels==3.0.5
 attrs==23.1.0
+wordfilter==0.2.7


### PR DESCRIPTION
### Works with frontend PR : https://github.com/massenergize/frontend-portal/pull/1208 

Just modified Mattea's username validation code a bit. 

- [x] There was a bug with username validation. Any username always returned taken and suggested a new one even though the username was unique. So I fixed that one.
- [x] I introduced a new plugin "World filter". That is the plugin that checks if the username contains any profane words. Here is the list of profaned words that the plugin uses https://github.com/dariusk/wordfilter/blob/master/lib/badwords.json . If you find that there is a bad word that is not in the list, you can add it too, like I did here: 
<img width="689" alt="Screenshot 2023-06-12 at 12 41 08" src="https://github.com/massenergize/api/assets/26961591/79fadc7d-2f71-4fcf-95fd-d71b5d72aae3">

