### PR TITLE
Fix route permissions so superadmins always have access

### DIFF
--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -52,6 +52,7 @@ from _main_.utils.massenergize_errors import (
     MassEnergizeAPIError,
     InvalidResourceError,
     CustomMassenergizeError,
+    NotAuthorizedError,
 )
 from _main_.utils.context import Context
 from api.store.graph import GraphStore
@@ -799,10 +800,12 @@ class CommunityStore:
             community_id = args.pop("community_id", None)
             website = args.pop("website", None)
             logo = args.pop("logo", None)
+
             # admins shouldn't be able to update data of other communities
-            if context.user_is_community_admin:
-                if not is_admin_of_community(context, community_id):
-                    return None, CustomMassenergizeError('You are not authorized')
+            if not is_admin_of_community(context, community_id):
+                return None, NotAuthorizedError()
+            
+            if not context.user_is_super_admin:
                 args = remove_cadmin_locked_fields(args)
               
 

--- a/src/api/store/download.py
+++ b/src/api/store/download.py
@@ -1241,7 +1241,7 @@ class DownloadStore:
         try:
             self.community_id = community_id
             if community_id:
-                if context.user_is_community_admin and not is_admin_of_community(context, community_id):
+                if not is_admin_of_community(context, community_id):
                     return EMPTY_DOWNLOAD, NotAuthorizedError()
                 community_name = Community.objects.get(id=community_id).name
                 return (
@@ -1281,21 +1281,18 @@ class DownloadStore:
     ) -> Tuple[list, MassEnergizeAPIError]:
         self.community_id = community_id
         try:
-# Allow this download only if the user is a community admin and an admin to the community or a superadm
-            if context.user_is_community_admin or context.user_is_super_admin:
-                if context.user_is_community_admin and not is_admin_of_community(context, community_id):
-                    return EMPTY_DOWNLOAD, NotAuthorizedError()
-
-                community = Community.objects.get(id=community_id)
-                if community:
-                    return (
-                        self._community_teams_download(community.id),
-                        community.name,
-                    ), None
-                else:
-                    return EMPTY_DOWNLOAD, InvalidResourceError()
-            else:
+            # Allow this download only if the user is a community admin and an admin to the community or a superadm
+            if not is_admin_of_community(context, community_id):
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
+
+            community = Community.objects.get(id=community_id)
+            if community:
+                return (
+                    self._community_teams_download(community.id),
+                    community.name,
+                ), None
+            else:
+                return EMPTY_DOWNLOAD, InvalidResourceError()
         except Exception as e:
             capture_message(str(e), level="error")
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
@@ -1308,7 +1305,7 @@ class DownloadStore:
             if not context.user_is_admin():
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
             if community_id: 
-                if context.user_is_community_admin and not is_admin_of_community(context, community_id):
+                if not is_admin_of_community(context, community_id):
                     return EMPTY_DOWNLOAD, NotAuthorizedError()
                 community_name = Community.objects.get(id=community_id).name
                 return (

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -7,6 +7,7 @@ from _main_.utils.massenergize_errors import (
     MassEnergizeAPIError,
     InvalidResourceError,
     CustomMassenergizeError,
+    NotAuthorizedError,
 )
 from _main_.utils.context import Context
 from .utils import get_admin_communities, unique_media_filename
@@ -28,8 +29,8 @@ class MessageStore:
                 return None, InvalidResourceError()
             message = Message.objects.filter(pk=message_id).first()
 
-            if context.user_is_community_admin and not is_admin_of_community(context, message.community.id):
-                return None, CustomMassenergizeError('You are not authorized')
+            if not is_admin_of_community(context, message.community.id):
+                return None, NotAuthorizedError()
 
             if not message:
                 return None, InvalidResourceError()
@@ -221,8 +222,8 @@ class MessageStore:
     def delete_message(self, message_id, context) -> Tuple[dict, MassEnergizeAPIError]:
         try:
             messages = Message.objects.filter(id=message_id)
-            if context.user_is_community_admin and not is_admin_of_community(context, messages.first().community.id):
-                return None, CustomMassenergizeError('You are not authorized')
+            if not is_admin_of_community(context, messages.first().community.id):
+                return None, NotAuthorizedError()
             messages.update(is_deleted=True)
             message = messages.first()
             # TODO: also remove it from all places that it was ever set in many to many or foreign key

--- a/src/api/store/page_settings.py
+++ b/src/api/store/page_settings.py
@@ -1,4 +1,4 @@
-from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
+from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError, NotAuthorizedError
 from api.tests.common import RESET
 from api.utils.api_utils import is_admin_of_community
 from .utils import get_community
@@ -34,8 +34,8 @@ class PageSettingsStore:
       return None, CustomMassenergizeError(e)
   
   def list_page_settings(self,context, community_id) -> Tuple[list, MassEnergizeAPIError]:
-    if context.user_is_community_admin and not is_admin_of_community(context, community_id):
-        return None, CustomMassenergizeError('You are not authorized')
+    if not is_admin_of_community(context, community_id):
+        return None, NotAuthorizedError()
     page_settings = self.pageSettingsModel.objects.filter(community__id=community_id)
     if not page_settings:
       return [], None
@@ -54,8 +54,8 @@ class PageSettingsStore:
     page_setting = self.pageSettingsModel.objects.filter(id=page_setting_id)
     if not page_setting:
       return None, InvalidResourceError()
-    if context.user_is_community_admin and not is_admin_of_community(context, page_setting.first().community.id):
-        return None, CustomMassenergizeError('You are not authorized')
+    if not is_admin_of_community(context, page_setting.first().community.id):
+        return None, NotAuthorizedError()
     
 
     args['is_published'] = args.pop('is_published', '').lower() == 'true'
@@ -85,15 +85,15 @@ class PageSettingsStore:
     if not page_settings:
       return None, InvalidResourceError()
     
-    if context.user_is_community_admin and not is_admin_of_community(context, page_settings.first().community.id):
-        return None, CustomMassenergizeError('You are not authorized')
+    if not is_admin_of_community(context, page_settings.first().community.id):
+        return None, NotAuthorizedError()
     
     page_settings.update(**{'is_deleted': True})
     return page_settings.first(), None
   
   def list_page_settings_for_community_admin(self, context, community_id) -> Tuple[list, MassEnergizeAPIError]:
-    if context.user_is_community_admin and not is_admin_of_community(context, community_id):
-        return None, CustomMassenergizeError('You are not authorized')
+    if not is_admin_of_community(context, community_id):
+        return None, NotAuthorizedError()
     page_settings = self.pageSettingsModel.objects.filter(community__id=community_id)
     return page_settings, None
   

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -351,7 +351,7 @@ class TeamStore:
         return None, InvalidResourceError()
       
       #  is context user an admin of the primary community?
-      if context.user_is_community_admin and not is_admin_of_community(context, teams.first().primary_community.id):
+      if not is_admin_of_community(context, teams.first().primary_community.id):
         return None, NotAuthorizedError()
       
       team_member = TeamMember.objects.filter(team=teams.first(), user=context.user_id).first()
@@ -419,8 +419,8 @@ class TeamStore:
 
       team = Team.objects.get(id=team_id)
 
-      if context.user_is_community_admin and not is_admin_of_community(context, team.primary_community.id):
-          return None, CustomMassenergizeError('You are not authorized to add members to this team')
+      if not is_admin_of_community(context, team.primary_community.id):
+          return None, NotAuthorizedError()
 
       if user_id:
         user = UserProfile.objects.get(id=user_id)
@@ -451,8 +451,8 @@ class TeamStore:
       elif email:
         user = UserProfile.objects.get(email=email)
 
-      if context.user_is_community_admin and not is_admin_of_community(context, team.primary_community.id):
-          return None, CustomMassenergizeError('You are not authorized to remove members from this team')
+      if not is_admin_of_community(context, team.primary_community.id):
+          return None, NotAuthorizedError()
 
       team_member = TeamMember.objects.filter(team__id=team_id, user=user)
       if team_member.count() > 0:
@@ -479,8 +479,8 @@ class TeamStore:
       
       team = Team.objects.filter(id=team_id).first()
       # for cadmins, allow only if admin of teams parent community
-      if context.user_is_community_admin and not is_admin_of_community(context, team.primary_community.id):
-          return None, CustomMassenergizeError('You are not authorized to view members of this team')
+      if not is_admin_of_community(context, team.primary_community.id):
+          return None, NotAuthorizedError()
 
       members = TeamMember.objects.filter(is_deleted=False, team__id=team_id, user__accepts_terms_and_conditions=True, user__is_deleted=False, *filter_params)
       return members.distinct(), None
@@ -544,7 +544,7 @@ class TeamStore:
         teams = Team.objects.filter(communities__id__in = comm_ids, is_deleted=False, *filter_params).select_related('logo', 'primary_community')
         return teams.distinct(), None
       
-      if context.user_is_community_admin and not is_admin_of_community(context, community_id):
+      if not is_admin_of_community(context, community_id):
           return None, CustomMassenergizeError('You are not authorized to view members of this team')
       teams = Team.objects.filter(Q(primary_community__id=community_id,is_published=True)|Q(communities__id=community_id), is_deleted=False,*filter_params).select_related('logo', 'primary_community')   
       return teams.distinct(), None

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -484,8 +484,8 @@ class UserStore:
       print(err)
       return [], None
     
-    if context.user_is_community_admin and not is_admin_of_community(context, community_id):
-        return None, CustomMassenergizeError('You are not authorized to view users of this community')
+    if not is_admin_of_community(context, community_id):
+        return None, NotAuthorizedError()
     return community.userprofile_set.all(), None
   
   def list_publicview(self, context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -836,8 +836,8 @@ class UserStore:
         print(err)
         return [], None
       
-      if context.user_is_community_admin and not is_admin_of_community(context, community_id):
-          return None, CustomMassenergizeError('You are not authorized to view users of this community')
+      if not is_admin_of_community(context, community_id):
+          return None, NotAuthorizedError()
       
       users = [cm.user for cm in CommunityMember.objects.filter(community=community, is_deleted=False, user__is_deleted=False)]
       users = remove_dups(users)

--- a/src/api/utils/api_utils.py
+++ b/src/api/utils/api_utils.py
@@ -5,6 +5,10 @@ from database.models import CommunityAdminGroup, UserProfile
 
 
 def is_admin_of_community(context, community_id):
+    # super admins are admins of any community
+    if context.user_is_super_admin: return True
+    if not context.user_is_community_admin: return False
+
     user_id = context.user_id
     user_email = context.user_email
     if not community_id:


### PR DESCRIPTION
This PR addresses issue 727 (Community Admins who are also Super Admins should have admin access to any community.