### PR TITLE
Cadmin activities will now exclude sadmin footages

### DIFF
--- a/src/_main_/utils/footage/spy.py
+++ b/src/_main_/utils/footage/spy.py
@@ -405,6 +405,6 @@ class Spy:
             return Footage.objects.filter(
                 portal=FootageConstants.on_admin_portal(),
                 communities__id__in = communities
-            ).distinct().order_by("-id")[:LIMIT]
+            ).exclude(actor__is_super_admin=True).distinct().order_by("-id")[:LIMIT]
         except Exception as e:
             Console.log("Could not fetch footages for community admin", e)


### PR DESCRIPTION
####  Related [issue](https://github.com/massenergize/frontend-admin/issues/1001)

#### Change
- [x] Excluded sadmin footages when fetching activities(footages) for community admins

#### Demo
https://github.com/massenergize/api/assets/42780120/549f2cdc-33a8-442a-897a-63279d3301fa


