### PR TITLE
New Route for Event Sharing

### DIFF
--- a/src/api/handlers/event.py
+++ b/src/api/handlers/event.py
@@ -34,6 +34,7 @@ class EventHandler(RouteHandler):
     self.add("/events.todo", self.save_for_later)
     self.add("/events.exceptions.list", self.list_exceptions)
     self.add("/events.date.update", self.update_recurring_date)
+    self.add("/events.share", self.share_event)
 
     #admin routes
     self.add("/events.listForCommunityAdmin", self.community_admin_list)
@@ -389,3 +390,21 @@ class EventHandler(RouteHandler):
       return err
 
     return MassenergizeResponse(data=events)
+
+
+  @admins_only
+  def share_event(self, request):
+    context: Context = request.context
+    args: dict = context.args
+    
+    self.validator.expect("event_id", int, is_required=True)
+    self.validator.expect("shared_to","str_list", is_required=True)
+    args, err = self.validator.verify(args, strict=True)
+
+    if err:
+      return err
+
+    event_info, err = self.service.share_event(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=event_info)

--- a/src/api/services/event.py
+++ b/src/api/services/event.py
@@ -217,6 +217,13 @@ class EventService:
     if err:
       return None, err
     return serialize(event), None
+  
+
+  def share_event(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
+    event, err = self.store.share_event(context, args)
+    if err:
+      return None, err
+    return serialize(event), None
 
   def rank_event(self, args, context) -> Tuple[dict, MassEnergizeAPIError]:
     event, err = self.store.rank_event(args,context)

--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -327,8 +327,9 @@ class ActionStore:
 
       # TODO: could allow content creator to delete until it is published
       # otherwise you need to be a super admin or admin of that community
-      if not is_admin_of_community(context, action_to_delete.community.id):
-        return None, NotAuthorizedError()
+      if action_to_delete.community:
+        if not is_admin_of_community(context, action_to_delete.community.id):
+          return None, NotAuthorizedError()
         
       action_to_delete.is_deleted = True 
       action_to_delete.save()

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -896,3 +896,23 @@ class EventStore:
     except Exception as e:
       capture_message(str(e), level="error")
       return None, CustomMassenergizeError(e)
+    
+
+
+  def share_event(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
+    try:
+      event_id = args.pop("event_id", None)
+      event = Event.objects.filter(id=event_id).first()
+      shared_to = args.pop("shared_to", None)
+      if shared_to:
+        first = shared_to[0]
+        if first == "reset": 
+          event.shared_to.clear()
+        else: event.shared_to.set(shared_to)
+      event.save()
+
+
+      return event, None
+    except Exception as e:
+      capture_message(str(e), level="error")
+      return None, CustomMassenergizeError(e)

--- a/src/api/tests/test_actions.py
+++ b/src/api/tests/test_actions.py
@@ -193,6 +193,7 @@ class ActionHandlerTest(TestCase):
       # test as sadmin
       signinAs(self.client, self.SADMIN)
       response = self.client.post('/api/actions.delete', urlencode({"action_id": self.ACTION5.id}), content_type="application/x-www-form-urlencoded").toDict()
+
       self.assertTrue(response["success"])
       self.assertTrue(response["data"]["is_deleted"])
 

--- a/src/api/tests/test_events.py
+++ b/src/api/tests/test_events.py
@@ -395,13 +395,19 @@ class EventsTestCase(TestCase):
 
 
     def test_events_sharing(self):
-        # test share event to community
+        # test share event to community as cadmin
         signinAs(self.client, self.CADMIN)
-        response =self.client.post(
-            '/api/events.share',
-            data=f"event_id={self.EVENT1.id}&shared_to={self.COMMUNITY.id}",
-            content_type="application/x-www-form-urlencoded",
-        ).json()
+        response =self.client.post('/api/events.share',data=f"event_id={self.EVENT1.id}&shared_to={self.COMMUNITY.id}",content_type="application/x-www-form-urlencoded" ).json()
         self.assertTrue(response["success"])
+
+        # test share event to community as normal user
+        signinAs(self.client, self.USER)
+        response =self.client.post('/api/events.share',data=f"event_id={self.EVENT1.id}&shared_to={self.COMMUNITY.id}",content_type="application/x-www-form-urlencoded" ).json()
+        self.assertFalse(response["success"])
+
+        # test share event to community with improper args 
+        signinAs(self.client, self.USER)
+        response =self.client.post('/api/events.share',data=f"event_id={self.EVENT1.id}",content_type="application/x-www-form-urlencoded" ).json()
+        self.assertFalse(response["success"])
 
         


### PR DESCRIPTION
####  Related [issue](https://github.com/massenergize/api/issues/730)
closes #730 

#### Changes
- Added `/events.share` route for event sharing instead of `/events.update` which was causing issues for unauthorised users.
- Fixed broken tests
- Added unit tests for the new route

