### PR TITLE
media lib footage resolved

### DIFF
--- a/src/api/store/media_library.py
+++ b/src/api/store/media_library.py
@@ -148,7 +148,7 @@ class MediaLibraryStore:
         return True, None
 
     def addToGallery(self, args,context):
-        community_ids = args.get("community_ids")
+        community_ids = args.get("community_ids", [])
         user_id = args.get("user_id")
         title = args.get("title") or "Gallery Upload"
         file = args.get("file")

--- a/src/api/store/media_library.py
+++ b/src/api/store/media_library.py
@@ -181,7 +181,7 @@ class MediaLibraryStore:
             info=info,
         )
         # ----------------------------------------------------------------
-        Spy.create_media_footage(media = [user_media.media], communities = [communities], context = context,  type = FootageConstants.create(), notes=f"Media ID({user_media.media.id})")
+        Spy.create_media_footage(media = [user_media.media], communities = [*community_ids], context = context,  type = FootageConstants.create(), notes=f"Media ID({user_media.media.id})")
         # ----------------------------------------------------------------
         return user_media, None
 


### PR DESCRIPTION
####  Related [https://github.com/massenergize/api/issues/735](https://github.com/massenergize/api/issues/735)
#### Works With [PR-https://github.com/massenergize/frontend-admin/pull/1033 ](https://github.com/massenergize/frontend-admin/pull/1033)

#### Why Error and Fix
The` .set` method of the M2M relationship accepts a list of `ids,` but we were passing a list of objects.  This Pr fixes this issue by replacing the list of objects with the list of ids
