### PR TITLE
Events nudge

### DIFF
--- a/src/task_queue/events_nudge/user_event_nudge.py
+++ b/src/task_queue/events_nudge/user_event_nudge.py
@@ -113,8 +113,15 @@ def get_community_events(community_id):
     return events
 
 
-def get_community_users(community_id):
+def get_community_users(community_id, flag):
    users = UserProfile.objects.filter(is_deleted=False, accepts_terms_and_conditions=True, communities__id=community_id, is_super_admin=False, is_community_admin=False, is_vendor=False)
+
+#    check if user is in flag
+   if flag.user_audience == "SPECIFIC":
+       users = users.filter(id__in=[str(u.id) for u in flag.users.all()])
+   elif flag.user_audience == "ALL_EXCEPT":
+       users = users.exclude(id__in=[str(u.id) for u in flag.users.all()])
+
    return users
 
 def generate_change_pref_url(subdomain):
@@ -193,7 +200,7 @@ def send_automated_nudge(events, user, community):
         user_is_ready_for_nudge = should_user_get_nudged(user)
 
         if user_is_ready_for_nudge:
-            print("sending nudge")
+            print("sending nudge .......")
             is_sent = send_events_report_email(name, email, events, community)
             if not is_sent:
                 print( f"**** Failed to send email to {name} for community {community.name} ****")
@@ -222,7 +229,6 @@ def get_user_events(notification_dates, community_events):
         return community_events.filter(Q(published_at__range=[a_week_ago, today]))
     
     user_event_nudge = notification_dates.get("user_event_nudge", None)
-
     if user_event_nudge:
         last_received_at = datetime.datetime.strptime(user_event_nudge, '%Y-%m-%d')
         date_aware = timezone.make_aware(last_received_at, timezone=timezone.get_default_timezone())
@@ -233,15 +239,6 @@ def get_user_events(notification_dates, community_events):
 
     return community_events.filter(Q(published_at__range=[last_time, today]))
 
-# don't update notification date unless a notification was actually sent
-#def update_user_notification_dates(communities, flag):
-#        allowed_communities = list(flag.communities.all())
-#        for community in communities:
-#            if flag.audience == "EVERYONE" or community in allowed_communities:
-#                users = get_community_users(community.id)
-#                emails = get_email_lists(users)
-#                for email in emails:
-#                    update_last_notification_dates(email)
 
 '''
 Note: This function only get email as argument when the
@@ -251,7 +248,7 @@ nudge is requested on demand by a cadmin on user portal.
 def prepare_user_events_nudge(email=None, community_id=None):
     try:
         flag = FeatureFlag.objects.filter(key=USER_EVENT_NUDGE_KEY).first()
-        allowed_communities = list(flag.communities.all())
+        # allowed_communities = list(flag.communities.all())
 
         communities = Community.objects.filter(is_published=True, is_deleted=False)
         if email and community_id:
@@ -262,20 +259,19 @@ def prepare_user_events_nudge(email=None, community_id=None):
             send_user_requested_nudge(events, user, community)
 
             return True
-      
-        for community in communities:
-            if flag.audience == "EVERYONE" or community in allowed_communities:
-                print(community)
-                events = get_community_events(community.id)
-                users = get_community_users(community.id)
-                for user in users:
-                    print(user)
-                    events = get_user_events(user.notification_dates, events)
-                    print(events)
-                    send_automated_nudge(events, user, community)
         
-        # Only update user notification date is an email was actually sent
-        # update_user_notification_dates(communities, flag)
+        if flag.audience == "SPECIFIC":
+            communities = communities.filter(id__in=[str(u.id) for u in flag.communities.all()])
+        elif flag.audience == "ALL_EXCEPT":
+            communities = communities.exclude(id__in=[str(u.id) for u in flag.communities.all()])
+        # print("=== communities: " , len(communities))
+        for community in communities:
+            # if flag.audience == "EVERYONE" or community in allowed_communities:
+            events = get_community_events(community.id)
+            users = get_community_users(community.id, flag)
+            for user in users:
+                events = get_user_events(user.notification_dates, events)
+                send_automated_nudge(events, user, community)
         
         return True   
     except Exception as e:


### PR DESCRIPTION
####  Related to [https://github.com/massenergize/api/issues/743](https://github.com/massenergize/api/issues/743)

#### Changes
- [x] User and cadmin events nudge now checks the audience type in feature flag to either include or exclude communities or users.



