### PR TITLE
Add arguments to communities.list for geographic range.

### DIFF
--- a/src/api/handlers/community.py
+++ b/src/api/handlers/community.py
@@ -9,282 +9,282 @@ from _main_.utils.context import Context
 from api.decorators import admins_only, super_admins_only, login_required
 from _main_.utils.massenergize_errors import CustomMassenergizeError
 
-
 class CommunityHandler(RouteHandler):
-    def __init__(self):
-        super().__init__()
-        self.service = CommunityService()
-        self.registerRoutes()
 
-    def registerRoutes(self) -> None:
-        self.add("/communities.info", self.info)
-        self.add("/communities.create", self.create)
-        self.add("/communities.add", self.create)
-        self.add("/communities.list", self.list)
-        self.add("/communities.update", self.update)
-        self.add("/communities.delete", self.delete)
-        self.add("/communities.remove", self.delete)
-        self.add("/communities.graphs", self.info)
-        self.add("/communities.data", self.info)
-        self.add("/communities.join", self.join)
-        self.add("/communities.leave", self.leave)
-        self.add("/communities.custom.website.add", self.add_custom_website)
-        self.add("/communities.actions.completed", self.actions_completed)
+  def __init__(self):
+    super().__init__()
+    self.service = CommunityService()
+    self.registerRoutes()
 
-        # admin routes
-        self.add("/communities.listForCommunityAdmin", self.community_admin_list)
-        self.add(
-            "/communities.others.listForCommunityAdmin",
-            self.list_other_communities_for_cadmin,
-        )
-        self.add("/communities.listForSuperAdmin", self.super_admin_list)
+  def registerRoutes(self) -> None:
+    self.add("/communities.info", self.info) 
+    self.add("/communities.create", self.create)
+    self.add("/communities.add", self.create)
+    self.add("/communities.list", self.list)
+    self.add("/communities.update", self.update)
+    self.add("/communities.delete", self.delete)
+    self.add("/communities.remove", self.delete)
+    self.add("/communities.graphs", self.info)
+    self.add("/communities.data", self.info)
+    self.add("/communities.join", self.join)
+    self.add("/communities.leave", self.leave)
+    self.add("/communities.custom.website.add", self.add_custom_website)
+    self.add("/communities.actions.completed", self.actions_completed)
 
-    def info(self, request):
-        context: Context = request.context
-        args: dict = context.args
+    #admin routes
+    self.add("/communities.listForCommunityAdmin", self.community_admin_list)
+    self.add("/communities.others.listForCommunityAdmin", self.list_other_communities_for_cadmin)
+    self.add("/communities.listForSuperAdmin", self.super_admin_list)
 
-        self.validator.expect("community_id", int)
-        self.validator.expect("subdomain", str)
-        self.validator.rename("id", "community_id")
-        args, err = self.validator.verify(args, strict=True)
-        if err:
-            return err
 
-        community_info, err = self.service.get_community_info(context, args)
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+  def info(self, request):
+    context: Context = request.context
+    args: dict = context.args
 
-    @login_required
-    def join(self, request):
-        context: Context = request.context
-        args: dict = context.args
+    self.validator.expect('community_id', int)
+    self.validator.expect('subdomain', str)
+    self.validator.rename('id', 'community_id')   
+    args, err = self.validator.verify(args, strict=True)
+    if err:
+      return err
 
-        # verify the body of the incoming request
-        # self.validator.expect("user_id", str, is_required=True) # the API already knows the user through the context
-        self.validator.expect("community_id", int, is_required=True)
-        args, err = self.validator.verify(args, strict=True)
-        if err:
-            return err
+    community_info, err = self.service.get_community_info(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=community_info)
 
-        # test for perms
-        # executor_id = context.user_id
 
-        # if executor_id == args.get("user_id", None) or context.user_is_admin():
-        community_info, err = self.service.join_community(context, args)
-        # else:
-        #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.join on this user")
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+  @login_required
+  def join(self, request):
+    context: Context = request.context
+    args: dict = context.args
 
-    @login_required
-    def leave(self, request):
-        context: Context = request.context
-        args: dict = context.args
+    # verify the body of the incoming request
+    # self.validator.expect("user_id", str, is_required=True) # the API already knows the user through the context
+    self.validator.expect("community_id", int, is_required=True)
+    args, err = self.validator.verify(args, strict=True)
+    if err:
+      return err
 
-        # verify the body of the incoming request
-        # self.validator.expect("user_id", str, is_required=True)
-        self.validator.expect("community_id", int, is_required=True)
-        args, err = self.validator.verify(args, strict=True)
-        if err:
-            return err
+    # test for perms
+    # executor_id = context.user_id
 
-        # test for perms
-        # executor_id = context.user_id
+    # if executor_id == args.get("user_id", None) or context.user_is_admin():
+    community_info, err = self.service.join_community(context, args)
+    # else:
+    #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.join on this user")
+    if err:
+      return err
+    return MassenergizeResponse(data=community_info)
 
-        # if executor_id == args.get("user_id", None):
-        community_info, err = self.service.leave_community(context, args)
-        # else:
-        #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.leave on this user")
 
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+  @login_required
+  def leave(self, request):
+    context: Context = request.context
+    args: dict = context.args
 
-    @super_admins_only
-    def create(self, request):
-        context: Context = request.context
-        args = context.get_request_body()
+    # verify the body of the incoming request
+    # self.validator.expect("user_id", str, is_required=True)
+    self.validator.expect("community_id", int, is_required=True)
+    args, err = self.validator.verify(args, strict=True)
+    if err:
+      return err
 
-        args["accepted_terms_and_conditions"] = parse_bool(
-            args.pop("accepted_terms_and_conditions", None)
-        )
-        if not args["accepted_terms_and_conditions"]:
-            return CustomMassenergizeError("Please accept the terms and conditions")
+    # test for perms
+    # executor_id = context.user_id
 
-        ok, err = check_length(args, "name", 3, 25)
-        if not ok:
-            return err
+    # if executor_id == args.get("user_id", None):
+    community_info, err = self.service.leave_community(context, args)
+    # else:
+    #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.leave on this user")
 
-        ok, err = check_length(args, "subdomain", 4, 20)
-        if not ok:
-            return err
+    if err:
+      return err
+    return MassenergizeResponse(data=community_info)
 
-        args["is_geographically_focused"] = parse_bool(
-            args.pop("is_geographically_focused", False)
-        )
-        args["is_demo"] = parse_bool(args.pop("is_demo", False))
-        args["is_published"] = parse_bool(args.pop("is_published", False))
-        args["is_approved"] = parse_bool(args.pop("is_approved", False))
 
-        args = rename_field(args, "image", "logo")
+  @super_admins_only
+  def create(self, request):
+    context: Context  = request.context
+    args = context.get_request_body()
 
-        args = parse_location(args)
-        if not args["is_geographically_focused"]:
-            args.pop("location", None)
+    args['accepted_terms_and_conditions'] = parse_bool(args.pop('accepted_terms_and_conditions', None))
+    if not args['accepted_terms_and_conditions']:
+      return CustomMassenergizeError("Please accept the terms and conditions")
+    
+    ok, err = check_length(args, 'name', 3, 25)
+    if not ok:
+      return err
+    
+    ok, err = check_length(args, 'subdomain', 4, 20)
+    if not ok:
+      return err
+      
+    args['is_geographically_focused'] = parse_bool(args.pop('is_geographically_focused', False))
+    args['is_demo'] = parse_bool(args.pop('is_demo', False))
+    args['is_published'] = parse_bool(args.pop('is_published', False))
+    args['is_approved'] = parse_bool(args.pop('is_approved', False))
 
-        community_info, err = self.service.create_community(context, args)
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+    args = rename_field(args, 'image', 'logo')
 
-    def list(self, request):
-        context: Context = request.context
-        args: dict = context.args
+    args = parse_location(args)
+    if not args['is_geographically_focused']:
+      args.pop('location', None)
+    
+    community_info, err = self.service.create_community(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=community_info)
 
-        self.validator.expect("zipcode", str, is_required=False)
-        self.validator.expect("max_distance", int, is_required=False)
 
-        args, err = self.validator.verify(args)
-        if err:
-            return err
+  def list(self, request):
+    context: Context = request.context
+    args: dict = context.args
 
-        community_info, err = self.service.list_communities(context, args)
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+    self.validator.expect("zipcode", str, is_required=False)
+    self.validator.expect("max_distance", int, is_required=False)
 
-    @admins_only
-    def update(self, request):
-        context: Context = request.context
-        args: dict = context.args
+    args, err = self.validator.verify(args)
+    if err:
+        return err
 
-        args = rename_field(args, "id", "community_id")
-        community_id = args.get("community_id", None)
-        if not community_id:
-            return CustomMassenergizeError("Please provide an ID")
+    community_info, err = self.service.list_communities(context, args)
+    if err:
+        return err
+    return MassenergizeResponse(data=community_info)
 
-        if args.get("name", None):
-            ok, err = check_length(args, "name", 3, 25)
-            if not ok:
-                return err
+  @admins_only
+  def update(self, request):
+    context: Context = request.context
+    args: dict = context.args
 
-        if args.get("subdomain", None):
-            ok, err = check_length(args, "subdomain", 4, 20)
-            if not ok:
-                return err
+    args = rename_field(args, 'id', 'community_id')
+    community_id = args.get('community_id', None)
+    if not community_id:
+      return CustomMassenergizeError('Please provide an ID')
 
-        if args.get("owner_name", None):
-            args["owner_name"] = args.get("owner_name", None)
-        if args.get("owner_email", None):
-            args["owner_email"] = args.get("owner_email", None)
-        if args.get("owner_phone_number", None):
-            args["owner_phone_number"] = args.get("owner_phone_number", None)
+    if(args.get('name', None)):
+      ok, err = check_length(args, 'name', 3, 25)
+      if not ok:
+        return err
+    
+    if(args.get('subdomain', None)):
+      ok, err = check_length(args, 'subdomain', 4, 20)
+      if not ok:
+        return err
 
-        if args.get("is_geographically_focused", False):
-            args["is_geographically_focused"] = parse_bool(
-                args.pop("is_geographically_focused", False)
-            )
-        if args.get("is_demo", False):
-            args["is_demo"] = parse_bool(args.pop("is_demo", False))
-        if args.get("is_published", None):
-            args["is_published"] = parse_bool(args.pop("is_published", None))
-        if args.get("is_approved", None):
-            args["is_approved"] = parse_bool(args.pop("is_approved", None))
+    if(args.get('owner_name', None)):
+      args['owner_name'] = args.get('owner_name', None)
+    if(args.get('owner_email', None)):
+      args['owner_email'] = args.get('owner_email', None)
+    if(args.get('owner_phone_number', None)):
+      args['owner_phone_number'] = args.get('owner_phone_number', None)
+    
+    if(args.get('is_geographically_focused', False)):
+      args['is_geographically_focused'] = parse_bool(args.pop('is_geographically_focused', False))
+    if(args.get('is_demo', False)):
+      args['is_demo'] = parse_bool(args.pop('is_demo', False))
+    if(args.get('is_published', None)):
+      args['is_published'] = parse_bool(args.pop('is_published', None))
+    if(args.get('is_approved', None)):
+      args['is_approved'] = parse_bool(args.pop('is_approved', None))
 
-        # eliminate if accidently provided
-        remove = args.pop("facebook_link", None)
-        remove = args.pop("twitter_link", None)
-        remove = args.pop("instagram_link", None)
+    # eliminate if accidently provided
+    remove = args.pop('facebook_link', None)
+    remove = args.pop('twitter_link', None)
+    remove = args.pop('instagram_link', None)
 
-        args = rename_field(args, "image", "logo")
-        args = parse_location(args)
+    args = rename_field(args, 'image', 'logo')
+    args = parse_location(args)
 
-        community_info, err = self.service.update_community(context, args)
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+    community_info, err = self.service.update_community(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=community_info)
 
-    @super_admins_only
-    def delete(self, request):
-        context: Context = request.context
-        args: dict = context.args
 
-        self.validator.expect("id", int, is_required=True)
-        self.validator.rename("community_id", "id")
+  @super_admins_only
+  def delete(self, request):
+    context: Context = request.context
+    args: dict = context.args
+    
+    self.validator.expect("id", int, is_required=True)
+    self.validator.rename("community_id", "id")
 
-        args, err = self.validator.verify(args)
-        if err:
-            return err
+    args, err = self.validator.verify(args)
+    if err:
+      return err
 
-        community_info, err = self.service.delete_community(args, context)
-        if err:
-            return err
-        return MassenergizeResponse(data=community_info)
+    community_info, err = self.service.delete_community(args,context)
+    if err:
+      return err
+    return MassenergizeResponse(data=community_info)
 
-    @admins_only
-    def list_other_communities_for_cadmin(self, request):
-        context: Context = request.context
 
-        communities, err = self.service.list_other_communities_for_cadmin(context)
-        if err:
-            return err
-        return MassenergizeResponse(data=communities)
+  @admins_only 
+  def list_other_communities_for_cadmin(self, request):
+    context: Context  = request.context
+  
+    communities, err = self.service.list_other_communities_for_cadmin(context)
+    if err:
+      return err
+    return MassenergizeResponse(data=communities)
 
-    @admins_only
-    def community_admin_list(self, request):
-        context: Context = request.context
-        # args = context.get_request_body()
-        communities, err = self.service.list_communities_for_community_admin(context)
-        if err:
-            return err
-        return MassenergizeResponse(data=communities)
+  @admins_only
+  def community_admin_list(self, request):  
+    context: Context  = request.context
+    #args = context.get_request_body()
+    communities, err = self.service.list_communities_for_community_admin(context)
+    if err:
+      return err
+    return MassenergizeResponse(data=communities)
 
-    @super_admins_only
-    def super_admin_list(self, request):
-        context: Context = request.context
-        # args = context.get_request_body()
-        communities, err = self.service.list_communities_for_super_admin(context)
-        if err:
-            return err
-        return MassenergizeResponse(data=communities)
 
-    @admins_only
-    def add_custom_website(self, request):
-        context: Context = request.context
-        args: dict = context.args
-        # verify the body of the incoming request
-        self.validator.expect("website", str, is_required=True)
-        self.validator.expect("subdomain", str)
-        self.validator.expect("community_id", int)
-        args, err = self.validator.verify(args, strict=True)
-        if err:
-            return err
+  @super_admins_only
+  def super_admin_list(self, request):
+    context: Context  = request.context
+    #args = context.get_request_body()
+    communities, err = self.service.list_communities_for_super_admin(context)
+    if err:
+      return err
+    return MassenergizeResponse(data=communities)
 
-        communities, err = self.service.add_custom_website(context, args)
-        if err:
-            return err
-        return MassenergizeResponse(data=communities)
 
-    def actions_completed(self, request):
-        context: Context = request.context
-        args: dict = context.args
+  @admins_only
+  def add_custom_website(self, request):
+    context: Context  = request.context
+    args: dict = context.args
+    # verify the body of the incoming request
+    self.validator.expect("website", str, is_required=True)
+    self.validator.expect("subdomain", str)
+    self.validator.expect("community_id", int)
+    args, err = self.validator.verify(args, strict=True)
+    if err:
+      return err
 
-        self.validator.expect("community_id", int, is_required=False)
-        self.validator.expect("subdomain", str, is_required=False)
-        self.validator.expect("communities", "str_list", is_required=False)
-        self.validator.expect("actions", "str_list", is_required=False)
-        self.validator.expect("time_range", str, is_required=False)
-        self.validator.expect("end_date", str, is_required=False)
-        self.validator.expect("start_date", str, is_required=False)
-        args, err = self.validator.verify(args)
-        if err:
-            return err
+    communities, err = self.service.add_custom_website(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=communities)
 
-        community_completed_actions, err = self.service.list_actions_completed(
-            context, args
-        )
-        if err:
-            return err
-        return MassenergizeResponse(data=community_completed_actions)
+  def actions_completed(self, request): 
+    context: Context = request.context
+    args: dict = context.args
+
+    self.validator.expect('community_id', int, is_required=False)
+    self.validator.expect('subdomain', str, is_required=False)
+    self.validator.expect('communities', "str_list", is_required=False)
+    self.validator.expect('actions', "str_list", is_required=False)
+    self.validator.expect('time_range', str, is_required=False)
+    self.validator.expect('end_date', str, is_required=False)
+    self.validator.expect('start_date', str, is_required=False)
+    args, err = self.validator.verify(args)
+    if err:
+      return err
+
+    community_completed_actions, err = self.service.list_actions_completed(context, args)
+    if err:
+      return err
+    return MassenergizeResponse(data=community_completed_actions)
+
+

--- a/src/api/handlers/community.py
+++ b/src/api/handlers/community.py
@@ -9,276 +9,282 @@ from _main_.utils.context import Context
 from api.decorators import admins_only, super_admins_only, login_required
 from _main_.utils.massenergize_errors import CustomMassenergizeError
 
+
 class CommunityHandler(RouteHandler):
+    def __init__(self):
+        super().__init__()
+        self.service = CommunityService()
+        self.registerRoutes()
 
-  def __init__(self):
-    super().__init__()
-    self.service = CommunityService()
-    self.registerRoutes()
+    def registerRoutes(self) -> None:
+        self.add("/communities.info", self.info)
+        self.add("/communities.create", self.create)
+        self.add("/communities.add", self.create)
+        self.add("/communities.list", self.list)
+        self.add("/communities.update", self.update)
+        self.add("/communities.delete", self.delete)
+        self.add("/communities.remove", self.delete)
+        self.add("/communities.graphs", self.info)
+        self.add("/communities.data", self.info)
+        self.add("/communities.join", self.join)
+        self.add("/communities.leave", self.leave)
+        self.add("/communities.custom.website.add", self.add_custom_website)
+        self.add("/communities.actions.completed", self.actions_completed)
 
-  def registerRoutes(self) -> None:
-    self.add("/communities.info", self.info) 
-    self.add("/communities.create", self.create)
-    self.add("/communities.add", self.create)
-    self.add("/communities.list", self.list)
-    self.add("/communities.update", self.update)
-    self.add("/communities.delete", self.delete)
-    self.add("/communities.remove", self.delete)
-    self.add("/communities.graphs", self.info)
-    self.add("/communities.data", self.info)
-    self.add("/communities.join", self.join)
-    self.add("/communities.leave", self.leave)
-    self.add("/communities.custom.website.add", self.add_custom_website)
-    self.add("/communities.actions.completed", self.actions_completed)
+        # admin routes
+        self.add("/communities.listForCommunityAdmin", self.community_admin_list)
+        self.add(
+            "/communities.others.listForCommunityAdmin",
+            self.list_other_communities_for_cadmin,
+        )
+        self.add("/communities.listForSuperAdmin", self.super_admin_list)
 
-    #admin routes
-    self.add("/communities.listForCommunityAdmin", self.community_admin_list)
-    self.add("/communities.others.listForCommunityAdmin", self.list_other_communities_for_cadmin)
-    self.add("/communities.listForSuperAdmin", self.super_admin_list)
+    def info(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
+        self.validator.expect("community_id", int)
+        self.validator.expect("subdomain", str)
+        self.validator.rename("id", "community_id")
+        args, err = self.validator.verify(args, strict=True)
+        if err:
+            return err
 
-  def info(self, request):
-    context: Context = request.context
-    args: dict = context.args
+        community_info, err = self.service.get_community_info(context, args)
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-    self.validator.expect('community_id', int)
-    self.validator.expect('subdomain', str)
-    self.validator.rename('id', 'community_id')   
-    args, err = self.validator.verify(args, strict=True)
-    if err:
-      return err
+    @login_required
+    def join(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-    community_info, err = self.service.get_community_info(context, args)
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+        # verify the body of the incoming request
+        # self.validator.expect("user_id", str, is_required=True) # the API already knows the user through the context
+        self.validator.expect("community_id", int, is_required=True)
+        args, err = self.validator.verify(args, strict=True)
+        if err:
+            return err
 
+        # test for perms
+        # executor_id = context.user_id
 
-  @login_required
-  def join(self, request):
-    context: Context = request.context
-    args: dict = context.args
+        # if executor_id == args.get("user_id", None) or context.user_is_admin():
+        community_info, err = self.service.join_community(context, args)
+        # else:
+        #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.join on this user")
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-    # verify the body of the incoming request
-    # self.validator.expect("user_id", str, is_required=True) # the API already knows the user through the context
-    self.validator.expect("community_id", int, is_required=True)
-    args, err = self.validator.verify(args, strict=True)
-    if err:
-      return err
+    @login_required
+    def leave(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-    # test for perms
-    # executor_id = context.user_id
+        # verify the body of the incoming request
+        # self.validator.expect("user_id", str, is_required=True)
+        self.validator.expect("community_id", int, is_required=True)
+        args, err = self.validator.verify(args, strict=True)
+        if err:
+            return err
 
-    # if executor_id == args.get("user_id", None) or context.user_is_admin():
-    community_info, err = self.service.join_community(context, args)
-    # else:
-    #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.join on this user")
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+        # test for perms
+        # executor_id = context.user_id
 
+        # if executor_id == args.get("user_id", None):
+        community_info, err = self.service.leave_community(context, args)
+        # else:
+        #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.leave on this user")
 
-  @login_required
-  def leave(self, request):
-    context: Context = request.context
-    args: dict = context.args
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-    # verify the body of the incoming request
-    # self.validator.expect("user_id", str, is_required=True)
-    self.validator.expect("community_id", int, is_required=True)
-    args, err = self.validator.verify(args, strict=True)
-    if err:
-      return err
+    @super_admins_only
+    def create(self, request):
+        context: Context = request.context
+        args = context.get_request_body()
 
-    # test for perms
-    # executor_id = context.user_id
+        args["accepted_terms_and_conditions"] = parse_bool(
+            args.pop("accepted_terms_and_conditions", None)
+        )
+        if not args["accepted_terms_and_conditions"]:
+            return CustomMassenergizeError("Please accept the terms and conditions")
 
-    # if executor_id == args.get("user_id", None):
-    community_info, err = self.service.leave_community(context, args)
-    # else:
-    #   return CustomMassenergizeError("Executor doesn't have sufficient permissions to use community.leave on this user")
+        ok, err = check_length(args, "name", 3, 25)
+        if not ok:
+            return err
 
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+        ok, err = check_length(args, "subdomain", 4, 20)
+        if not ok:
+            return err
 
+        args["is_geographically_focused"] = parse_bool(
+            args.pop("is_geographically_focused", False)
+        )
+        args["is_demo"] = parse_bool(args.pop("is_demo", False))
+        args["is_published"] = parse_bool(args.pop("is_published", False))
+        args["is_approved"] = parse_bool(args.pop("is_approved", False))
 
-  @super_admins_only
-  def create(self, request):
-    context: Context  = request.context
-    args = context.get_request_body()
+        args = rename_field(args, "image", "logo")
 
-    args['accepted_terms_and_conditions'] = parse_bool(args.pop('accepted_terms_and_conditions', None))
-    if not args['accepted_terms_and_conditions']:
-      return CustomMassenergizeError("Please accept the terms and conditions")
-    
-    ok, err = check_length(args, 'name', 3, 25)
-    if not ok:
-      return err
-    
-    ok, err = check_length(args, 'subdomain', 4, 20)
-    if not ok:
-      return err
-      
-    args['is_geographically_focused'] = parse_bool(args.pop('is_geographically_focused', False))
-    args['is_demo'] = parse_bool(args.pop('is_demo', False))
-    args['is_published'] = parse_bool(args.pop('is_published', False))
-    args['is_approved'] = parse_bool(args.pop('is_approved', False))
+        args = parse_location(args)
+        if not args["is_geographically_focused"]:
+            args.pop("location", None)
 
-    args = rename_field(args, 'image', 'logo')
+        community_info, err = self.service.create_community(context, args)
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-    args = parse_location(args)
-    if not args['is_geographically_focused']:
-      args.pop('location', None)
-    
-    community_info, err = self.service.create_community(context, args)
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+    def list(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
+        self.validator.expect("zipcode", str, is_required=False)
+        self.validator.expect("max_distance", int, is_required=False)
 
-  def list(self, request):
-    context: Context  = request.context
+        args, err = self.validator.verify(args)
+        if err:
+            return err
 
-    args = context.args
-    community_info, err = self.service.list_communities(context, args)
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+        community_info, err = self.service.list_communities(context, args)
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-  @admins_only
-  def update(self, request):
-    context: Context = request.context
-    args: dict = context.args
+    @admins_only
+    def update(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-    args = rename_field(args, 'id', 'community_id')
-    community_id = args.get('community_id', None)
-    if not community_id:
-      return CustomMassenergizeError('Please provide an ID')
+        args = rename_field(args, "id", "community_id")
+        community_id = args.get("community_id", None)
+        if not community_id:
+            return CustomMassenergizeError("Please provide an ID")
 
-    if(args.get('name', None)):
-      ok, err = check_length(args, 'name', 3, 25)
-      if not ok:
-        return err
-    
-    if(args.get('subdomain', None)):
-      ok, err = check_length(args, 'subdomain', 4, 20)
-      if not ok:
-        return err
+        if args.get("name", None):
+            ok, err = check_length(args, "name", 3, 25)
+            if not ok:
+                return err
 
-    if(args.get('owner_name', None)):
-      args['owner_name'] = args.get('owner_name', None)
-    if(args.get('owner_email', None)):
-      args['owner_email'] = args.get('owner_email', None)
-    if(args.get('owner_phone_number', None)):
-      args['owner_phone_number'] = args.get('owner_phone_number', None)
-    
-    if(args.get('is_geographically_focused', False)):
-      args['is_geographically_focused'] = parse_bool(args.pop('is_geographically_focused', False))
-    if(args.get('is_demo', False)):
-      args['is_demo'] = parse_bool(args.pop('is_demo', False))
-    if(args.get('is_published', None)):
-      args['is_published'] = parse_bool(args.pop('is_published', None))
-    if(args.get('is_approved', None)):
-      args['is_approved'] = parse_bool(args.pop('is_approved', None))
+        if args.get("subdomain", None):
+            ok, err = check_length(args, "subdomain", 4, 20)
+            if not ok:
+                return err
 
-    # eliminate if accidently provided
-    remove = args.pop('facebook_link', None)
-    remove = args.pop('twitter_link', None)
-    remove = args.pop('instagram_link', None)
+        if args.get("owner_name", None):
+            args["owner_name"] = args.get("owner_name", None)
+        if args.get("owner_email", None):
+            args["owner_email"] = args.get("owner_email", None)
+        if args.get("owner_phone_number", None):
+            args["owner_phone_number"] = args.get("owner_phone_number", None)
 
-    args = rename_field(args, 'image', 'logo')
-    args = parse_location(args)
+        if args.get("is_geographically_focused", False):
+            args["is_geographically_focused"] = parse_bool(
+                args.pop("is_geographically_focused", False)
+            )
+        if args.get("is_demo", False):
+            args["is_demo"] = parse_bool(args.pop("is_demo", False))
+        if args.get("is_published", None):
+            args["is_published"] = parse_bool(args.pop("is_published", None))
+        if args.get("is_approved", None):
+            args["is_approved"] = parse_bool(args.pop("is_approved", None))
 
-    community_info, err = self.service.update_community(context, args)
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+        # eliminate if accidently provided
+        remove = args.pop("facebook_link", None)
+        remove = args.pop("twitter_link", None)
+        remove = args.pop("instagram_link", None)
 
+        args = rename_field(args, "image", "logo")
+        args = parse_location(args)
 
-  @super_admins_only
-  def delete(self, request):
-    context: Context = request.context
-    args: dict = context.args
-    
-    self.validator.expect("id", int, is_required=True)
-    self.validator.rename("community_id", "id")
+        community_info, err = self.service.update_community(context, args)
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-    args, err = self.validator.verify(args)
-    if err:
-      return err
+    @super_admins_only
+    def delete(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-    community_info, err = self.service.delete_community(args,context)
-    if err:
-      return err
-    return MassenergizeResponse(data=community_info)
+        self.validator.expect("id", int, is_required=True)
+        self.validator.rename("community_id", "id")
 
+        args, err = self.validator.verify(args)
+        if err:
+            return err
 
-  @admins_only 
-  def list_other_communities_for_cadmin(self, request):
-    context: Context  = request.context
-  
-    communities, err = self.service.list_other_communities_for_cadmin(context)
-    if err:
-      return err
-    return MassenergizeResponse(data=communities)
+        community_info, err = self.service.delete_community(args, context)
+        if err:
+            return err
+        return MassenergizeResponse(data=community_info)
 
-  @admins_only
-  def community_admin_list(self, request):  
-    context: Context  = request.context
-    #args = context.get_request_body()
-    communities, err = self.service.list_communities_for_community_admin(context)
-    if err:
-      return err
-    return MassenergizeResponse(data=communities)
+    @admins_only
+    def list_other_communities_for_cadmin(self, request):
+        context: Context = request.context
 
+        communities, err = self.service.list_other_communities_for_cadmin(context)
+        if err:
+            return err
+        return MassenergizeResponse(data=communities)
 
-  @super_admins_only
-  def super_admin_list(self, request):
-    context: Context  = request.context
-    #args = context.get_request_body()
-    communities, err = self.service.list_communities_for_super_admin(context)
-    if err:
-      return err
-    return MassenergizeResponse(data=communities)
+    @admins_only
+    def community_admin_list(self, request):
+        context: Context = request.context
+        # args = context.get_request_body()
+        communities, err = self.service.list_communities_for_community_admin(context)
+        if err:
+            return err
+        return MassenergizeResponse(data=communities)
 
+    @super_admins_only
+    def super_admin_list(self, request):
+        context: Context = request.context
+        # args = context.get_request_body()
+        communities, err = self.service.list_communities_for_super_admin(context)
+        if err:
+            return err
+        return MassenergizeResponse(data=communities)
 
-  @admins_only
-  def add_custom_website(self, request):
-    context: Context  = request.context
-    args: dict = context.args
-    # verify the body of the incoming request
-    self.validator.expect("website", str, is_required=True)
-    self.validator.expect("subdomain", str)
-    self.validator.expect("community_id", int)
-    args, err = self.validator.verify(args, strict=True)
-    if err:
-      return err
+    @admins_only
+    def add_custom_website(self, request):
+        context: Context = request.context
+        args: dict = context.args
+        # verify the body of the incoming request
+        self.validator.expect("website", str, is_required=True)
+        self.validator.expect("subdomain", str)
+        self.validator.expect("community_id", int)
+        args, err = self.validator.verify(args, strict=True)
+        if err:
+            return err
 
-    communities, err = self.service.add_custom_website(context, args)
-    if err:
-      return err
-    return MassenergizeResponse(data=communities)
+        communities, err = self.service.add_custom_website(context, args)
+        if err:
+            return err
+        return MassenergizeResponse(data=communities)
 
-  def actions_completed(self, request): 
-    context: Context = request.context
-    args: dict = context.args
+    def actions_completed(self, request):
+        context: Context = request.context
+        args: dict = context.args
 
-    self.validator.expect('community_id', int, is_required=False)
-    self.validator.expect('subdomain', str, is_required=False)
-    self.validator.expect('communities', "str_list", is_required=False)
-    self.validator.expect('actions', "str_list", is_required=False)
-    self.validator.expect('time_range', str, is_required=False)
-    self.validator.expect('end_date', str, is_required=False)
-    self.validator.expect('start_date', str, is_required=False)
-    args, err = self.validator.verify(args)
-    if err:
-      return err
+        self.validator.expect("community_id", int, is_required=False)
+        self.validator.expect("subdomain", str, is_required=False)
+        self.validator.expect("communities", "str_list", is_required=False)
+        self.validator.expect("actions", "str_list", is_required=False)
+        self.validator.expect("time_range", str, is_required=False)
+        self.validator.expect("end_date", str, is_required=False)
+        self.validator.expect("start_date", str, is_required=False)
+        args, err = self.validator.verify(args)
+        if err:
+            return err
 
-    community_completed_actions, err = self.service.list_actions_completed(context, args)
-    if err:
-      return err
-    return MassenergizeResponse(data=community_completed_actions)
-
-
-
+        community_completed_actions, err = self.service.list_actions_completed(
+            context, args
+        )
+        if err:
+            return err
+        return MassenergizeResponse(data=community_completed_actions)

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -676,6 +676,9 @@ class CommunityStore:
 
                                 if distance_between_zipcodes <= max_distance:
                                     if community.id not in added_communities:
+                                        community.location[
+                                            "distance"
+                                        ] = distance_between_zipcodes
                                         filtered_communities.append(community)
                                         added_communities.append(community.id)
                         else:

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -65,15 +65,25 @@ from .utils import (
 from database.utils.common import json_loader
 from _main_.utils.constants import RESERVED_SUBDOMAIN_LIST
 from typing import Tuple
+import math
 import zipcodes
 from sentry_sdk import capture_message, capture_exception
 
 ALL = "all"
 
-cadmin_locked_fields=["subdomain", "is_geographically_focused", "locations", "Is_approved", "is_demo"]
+cadmin_locked_fields = [
+    "subdomain",
+    "is_geographically_focused",
+    "locations",
+    "Is_approved",
+    "is_demo",
+]
+
 
 def remove_cadmin_locked_fields(args):
-    return {key: value for key, value in args.items() if key not in cadmin_locked_fields}
+    return {
+        key: value for key, value in args.items() if key not in cadmin_locked_fields
+    }
 
 
 def _clone_page_settings(pageSettings, title, community):
@@ -97,8 +107,6 @@ def _clone_page_settings(pageSettings, title, community):
     page.save()
 
     return page
-
-
 
 
 class CommunityStore:
@@ -420,6 +428,34 @@ class CommunityStore:
             # should be a five character string
             community.locations.add(loc)
 
+    def _haversince_distance(self, lat1: int, lon1: int, lat2: int, lon2: int):
+        """
+        Calculate the great circle distance between two points.
+        """
+        # convert decimal degrees to radians
+        lat1 = math.radians(lat1)
+        lon1 = math.radians(lon1)
+        lat2 = math.radians(lat2)
+        lon2 = math.radians(lon2)
+
+        earth_radius = 6371  # km
+
+        # haversine formula
+        dlon = lon2 - lon1
+        dlat = lat2 - lat1
+        a = (
+            math.sin(dlat / 2) ** 2
+            + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+        )
+        c = 2 * math.asin(math.sqrt(a))
+
+        # calculate the distance in kilometers
+        distance = earth_radius * c
+        # convert to miles
+        distance = distance * 0.621371
+
+        return distance
+
     def _update_real_estate_units_with_community(self, community):
         """
         Utility function used when Community added or updated
@@ -551,7 +587,9 @@ class CommunityStore:
                 community=community, user=user
             ).first()
             if not community_member:
-                community_member = CommunityMember.objects.create(community=community, user=user, is_admin=False)
+                community_member = CommunityMember.objects.create(
+                    community=community, user=user, is_admin=False
+                )
 
             return user, None
         except Exception as e:
@@ -586,16 +624,66 @@ class CommunityStore:
     ) -> Tuple[list, MassEnergizeAPIError]:
         try:
             if context.is_sandbox:
-                communities = Community.objects.filter(
-                    is_deleted=False, is_approved=True
-                ).exclude(subdomain="template").order_by('name')
+                communities = (
+                    Community.objects.filter(is_deleted=False, is_approved=True)
+                    .exclude(subdomain="template")
+                    .order_by("name")
+                )
             else:
-                communities = Community.objects.filter(
-                    is_deleted=False, is_approved=True, is_published=True
-                ).exclude(subdomain="template").order_by('name')
+                communities = (
+                    Community.objects.filter(
+                        is_deleted=False, is_approved=True, is_published=True
+                    )
+                    .exclude(subdomain="template")
+                    .order_by("name")
+                )
 
             if not communities:
                 return [], None
+            # check for zipcode:
+            if zipcode := args.get("zipcode", None):
+
+                if zipcodes.is_real(zipcode):
+                    # filter communities by coordinates
+                    filtered_communities = []
+
+                    # get coordinates of the zipcode
+                    zipcode_info = zipcodes.matching(zipcode)
+                    zipcode_lat = zipcode_info[0]["lat"]
+                    zipcode_long = zipcode_info[0]["long"]
+
+                    max_distance = args.get("max_distance", 25)
+
+                    added_communities = []
+
+                    for community in communities:
+                        if community.is_geographically_focused:
+                            for location in community.locations.all():
+                                community_zipcode_info = zipcodes.matching(
+                                    location.zipcode
+                                )
+                                community_zipcode_lat = community_zipcode_info[0]["lat"]
+                                community_zipcode_long = community_zipcode_info[0][
+                                    "long"
+                                ]
+
+                                distance_between_zipcodes = self._haversince_distance(
+                                    float(zipcode_lat),
+                                    float(zipcode_long),
+                                    float(community_zipcode_lat),
+                                    float(community_zipcode_long),
+                                )
+
+                                if distance_between_zipcodes <= max_distance:
+                                    if community.id not in added_communities:
+                                        filtered_communities.append(community)
+                                        added_communities.append(community.id)
+                        else:
+                            filtered_communities.append(community)
+                    return filtered_communities, None
+                else:
+                    return [], CustomMassenergizeError("Invalid Zipcode")
+
             return communities, None
         except Exception as e:
             capture_exception(e)
@@ -804,10 +892,9 @@ class CommunityStore:
             # admins shouldn't be able to update data of other communities
             if not is_admin_of_community(context, community_id):
                 return None, NotAuthorizedError()
-            
+
             if not context.user_is_super_admin:
                 args = remove_cadmin_locked_fields(args)
-              
 
             # The set of zipcodes, stored as Location models, are what determines a boundary for a geograpically focussed community
             # This will work for the large majority of cases, but there may be some where a zip code overlaps a town or state boundary
@@ -956,7 +1043,11 @@ class CommunityStore:
                 user = UserProfile.objects.get(pk=context.user_id)
                 admin_groups = user.communityadmingroup_set.all()
                 communities = [a.community for a in admin_groups]
-                communities = list(Community.objects.filter(id__in={com.id for com in communities}).filter(*filter_params).order_by('name'))
+                communities = list(
+                    Community.objects.filter(id__in={com.id for com in communities})
+                    .filter(*filter_params)
+                    .order_by("name")
+                )
                 return communities, None
             else:
                 return [], None
@@ -971,7 +1062,11 @@ class CommunityStore:
             #   return None, CustomMassenergizeError("You are not a super admin or community admin")
             filter_params = get_communities_filter_params(context.get_params())
             # the order_by didn't work properly until I added list(), due to "lazy evaluation"
-            communities = list(Community.objects.filter(is_deleted=False, *filter_params).order_by('name'))
+            communities = list(
+                Community.objects.filter(is_deleted=False, *filter_params).order_by(
+                    "name"
+                )
+            )
             return communities, None
         except Exception as e:
             capture_exception(e)
@@ -1035,7 +1130,7 @@ class CommunityStore:
 
             actions_completed = []
             if not context.is_admin_site:
-                community = get_community_or_die(context, args)                
+                community = get_community_or_die(context, args)
                 actions_completed = count_action_completed_and_todos(
                     communities=[community],
                     time_range=time_range,

--- a/src/api/tests/test_communities.py
+++ b/src/api/tests/test_communities.py
@@ -175,6 +175,28 @@ class CommunitiesTestCase(TestCase):
     self.assertIs(1, len(list_response.get("data")))
     self.assertEqual(self.COMMUNITY.name, list_response.get("data")[0]['name'])
 
+    # try to list communities by zipcode when signed in as a user
+    signinAs(self.client, self.USER)
+    list_response = self.client.post('/api/communities.list', urlencode({"zipcode": '02148'}), content_type="application/x-www-form-urlencoded").toDict()
+
+    self.assertTrue(list_response["success"])
+    self.assertIs(1, len(list_response.get("data")))
+    self.assertEqual(self.COMMUNITY.name, list_response.get("data")[0]['name'])
+
+    # try to list communities with invalid zipcode
+    list_response = self.client.post('/api/communities.list', urlencode({"zipcode": '021'}), content_type="application/x-www-form-urlencoded").toDict()
+
+    self.assertFalse(list_response["success"])
+    self.assertIsNone(list_response.get("data"))
+    self.assertEqual("Invalid Zipcode", list_response.get("error"))
+
+    # try to list communities with invalid format zipcode
+    list_response = self.client.post('/api/communities.list', urlencode({"zipcode": '0214a'}), content_type="application/x-www-form-urlencoded").toDict()
+
+
+    self.assertFalse(list_response["success"])
+    self.assertIsNone(list_response.get("data"))
+
 
 
   def test_update(self):


### PR DESCRIPTION
####  Summary / Highlights
Added extra field  `distance` to `community.location` when `zipcode` argument is provided to `communities.list` to display the distance between given zipcode and community's zipcode. An optional `max_distance` with a default value of 25 miles will filter communities with a distance less than or equal to that value.  

#### Related Issue #748 

#### Requirements (place an `x` in each `[ ]`)
* [X] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've tested my changes manually.
* [X] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [X] I've given my PR a meaningful title.
* [X] I linked this PR to the relevant issue.
* [X] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
