### PR TITLE
779 - cadmin nudge issue

### DIFF
--- a/src/task_queue/events_nudge/cadmin_events_nudge.py
+++ b/src/task_queue/events_nudge/cadmin_events_nudge.py
@@ -44,7 +44,7 @@ def generate_event_list_for_community(com):
         community__is_published=True,
         is_published=True,
         is_deleted=False
-    ).exclude(community=com, shared_to__id=com.id)
+    ).exclude(community=com).exclude(shared_to__id=com.id).distinct()
     
     return {
         "events": prepare_events_email_data(events),


### PR DESCRIPTION
One line fix to prevent duplicate events and properly exclude events from your community or ones you've already shared.