### PR TITLE
841 - prevent deleted users from getting nudged

### DIFF
--- a/src/task_queue/nudges/user_event_nudge.py
+++ b/src/task_queue/nudges/user_event_nudge.py
@@ -115,7 +115,7 @@ def get_community_events(community_id):
 
 def get_community_users(community_id):
     community_members = CommunityMember.objects.filter(community__id=community_id, is_deleted=False).values_list("user", flat=True)
-    users = UserProfile.objects.filter(id__in=community_members, accepts_terms_and_conditions=True)
+    users = UserProfile.objects.filter(id__in=community_members, accepts_terms_and_conditions=True, is_deleted=False)
     return users
 
 def generate_change_pref_url(subdomain,email, login_method):


### PR DESCRIPTION
####  Summary / Highlights
Some deleted users have received nudges, because they hadn't been marked as deleted in CommunityMembers
Explicitly require is_deleted=False for users to get nudged

Resolves issue #841 