### PR TITLE
Fix for critical bug API 874 - cadmin events nudge fails

### DIFF
--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -192,8 +192,11 @@ def send_events_nudge(task=None):
             event_list = d.get("events", [])
             if len(admins) > 0 and len(event_list) > 0:
                 email_list = get_email_list(admins)
-                for name, email, user_info in email_list.items():
-                    stat = send_events_report(name, email, event_list, user_info)
+
+                #for name, email, user_info in email_list.items():
+                #    stat = send_events_report(name, email, event_list, user_info)
+                for name, email in email_list.items():
+                    stat = send_events_report(name, email, event_list)
                     if not stat:
                         print("send_events_report error return")
                         return False
@@ -205,9 +208,12 @@ def send_events_nudge(task=None):
         return False
 
 
-def send_events_report(name, email, event_list, user_info):
+#def send_events_report(name, email, event_list, user_info):
+def send_events_report(name, email, event_list):
     try:
-        login_method= (user_info or {}).get("login_method", None)
+        # 14-Dec-23 - fix for user_info not provided
+        user = UserProfile.objects.filter(email=email).first()
+        login_method= (user.user_info or {}).get("login_method", None)
         cred = encode_data_for_URL({"email": email, "login_method":login_method})
         change_preference_link = ADMIN_URL_ROOT+f"/admin/profile/preferences/?cred={cred}"
         data = {}


### PR DESCRIPTION
####  Summary / Highlights
This PR is to fix the bug #874 in production.

As described in the ticket, the event sharing nudge to cadmins has been failing for the last several weeks, since changes were made relating to the user sign on method (in user_info).

Testing should have caught this bug but it didn't.

This PR is to master, so the bug fix can be deployed this weekend before the nudge goes out on Monday.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)
We will see on Monday that the Cadmin Event sharing nudge goes out and the Task completes

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [x] I moved the linked issue to "QA Verification" now that it is ready to merge.
