### PR TITLE
Fix: Allow Super Admins to Delete Non-Super Admin Profile

### DIFF
--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -144,6 +144,8 @@ def _update_action_data_totals(action, household, delta):
       d.save()
 
 def can_be_deleted(user, context):
+  if context.user_is_super_admin and not user.is_super_admin:
+    return True
   if user.is_super_admin:
     return False
   if context.user_is_community_admin and  user.is_community_admin:


### PR DESCRIPTION
####  Summary / Highlights
This pull request addresses a key functionality update in the user management feature of our project.

- **Enhanced Deletion Permissions for Super Administrators**: A change has been made in the can_be_deleted function found in the userprofile API to enable super administrators to delete user profiles of non-super administrators. This provides super administrators with better control and ability to manage users in the application.

closes https://github.com/massenergize/frontend-admin/issues/1124

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
