### PR TITLE
Feature: Add 'Shared-To' Communities to Event Notification Settings

### DIFF
--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -994,6 +994,8 @@ class EventStore:
         except Exception as e:
             capture_message(str(e), level="error")
             return None, CustomMassenergizeError(e)
+
+            
     def create_event_reminder_settings(self, context: Context, args) -> Tuple[EventNudgeSetting, MassEnergizeAPIError]:
         try:
             event_id = args.pop("event_id", None)

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -1013,8 +1013,7 @@ class EventStore:
                     communities = Community.objects.filter(is_deleted=False).values_list('id', flat=True)
                 
                 elif context.user_is_community_admin:
-                    community_admin_group_id_set = set(
-                        user.communityadmingroup_set.values_list('id', flat=True)) if user else set()
+                    community_admin_group_id_set = set(user.communityadmingroup_set.values_list('id', flat=True)) if user else set()
                     communities_shared_to_set = set(event.communities_shared_to())
                     communities = list(community_admin_group_id_set.union(communities_shared_to_set))
                 
@@ -1022,9 +1021,7 @@ class EventStore:
             
             else:
                 communities_set = set(communities)
-                other_nudge_settings = EventNudgeSetting.objects.filter(event=event,
-                                                                        communities__in=communities).exclude(
-                    id=settings_id)
+                other_nudge_settings = EventNudgeSetting.objects.filter(event=event,communities__in=communities).exclude(id=settings_id)
                 
                 for nudge_setting in other_nudge_settings:
                     current_communities = set(nudge_setting.communities.values_list('id', flat=True))

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -994,35 +994,43 @@ class EventStore:
         except Exception as e:
             capture_message(str(e), level="error")
             return None, CustomMassenergizeError(e)
-
     def create_event_reminder_settings(self, context: Context, args) -> Tuple[EventNudgeSetting, MassEnergizeAPIError]:
         try:
-
             event_id = args.pop("event_id", None)
             communities = args.pop("community_ids", [])
-
             user = get_user_from_context(context)
             is_all_communities = communities and communities[0].lower() == "all"
-
+            
             event = Event.objects.filter(id=event_id).first()
             if not event:
                 return None, CustomMassenergizeError("Event with the given ID does not exist")
-
+            
             settings, exists = EventNudgeSetting.objects.get_or_create(event=event, **args)
-
+            settings_id = settings.id if settings else None
+            
             if is_all_communities:
                 if context.user_is_super_admin:
                     communities = Community.objects.filter(is_deleted=False).values_list('id', flat=True)
+                
                 elif context.user_is_community_admin:
-                    communities = [c.id for c in user.communityadmingroup_set.all()] if user else []
-                EventNudgeSetting.objects.filter(event=event).exclude( id=settings.id if settings else None).delete()
+                    community_admin_group_id_set = set(
+                        user.communityadmingroup_set.values_list('id', flat=True)) if user else set()
+                    communities_shared_to_set = set(event.communities_shared_to())
+                    communities = list(community_admin_group_id_set.union(communities_shared_to_set))
+                
+                EventNudgeSetting.objects.filter(event=event).exclude(id=settings_id).delete()
+            
             else:
-                 other_nudge_settings = EventNudgeSetting.objects.filter(event=event, communities__in=communities).exclude(id=settings.id)
-                 for nudge_setting in other_nudge_settings:
-                    for community in communities:
-                        nudge_setting.communities.remove(community)
-                        nudge_setting.save()
-
+                communities_set = set(communities)
+                other_nudge_settings = EventNudgeSetting.objects.filter(event=event,
+                                                                        communities__in=communities).exclude(
+                    id=settings_id)
+                
+                for nudge_setting in other_nudge_settings:
+                    current_communities = set(nudge_setting.communities.values_list('id', flat=True))
+                    communities_to_remove = communities_set.intersection(current_communities)
+                    nudge_setting.communities.remove(*communities_to_remove)
+            
             if exists:
                 settings.communities.add(*communities)
                 settings.last_updated_by = user
@@ -1032,10 +1040,9 @@ class EventStore:
                 settings.communities.set(communities)
                 settings.last_updated_by = user
                 settings.save()
-                
+            
             return event, None
-
-
+        
         except Exception as e:
             capture_message(str(e), level="error")
             return None, CustomMassenergizeError(e)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -2148,6 +2148,14 @@ class Event(models.Model):
     def info(self):
         data = model_to_dict(self, ["id", "name"])
         return data
+    def communities_shared_to(self):
+        communities = self.communities_under_publicity.all()
+        if self.publicity == EventConstants.open_to():
+            return communities
+        elif self.publicity == EventConstants.closed_to():
+            communities_ids = communities.values_list('id', flat=True)
+            return Community.objects.exclude(id__in=communities_ids)
+        return []
 
     def is_on_homepage(self) -> bool:
         is_used = False


### PR DESCRIPTION
####  Summary / Highlights
This pull request includes a new function in the database model to get the list of communities an event is shared with. Community admins can set notification settings for communities an event is shared with when they apply the settings to all communities.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
