### PR TITLE
Chore: Refine build and deployment strategy in Makefile and settings.py

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,13 +13,12 @@ start:
 	DJANGO_ENV=local python3 manage.py runserver
 .PHONY: start
 
-
-prepare-prod:
-	python3 deployment/prepare_to_deploy.py --prod 0 1
-.PHONY: prepare-prod
+#prepare-prod:
+#	python3 deployment/prepare_to_deploy.py --prod 0 1
+#.PHONY: prepare-prod
 
 VERSION=latest
-deploy-prod:
+build-and-push-prod:
 	$(eval VERSION := $(shell cat api_version_prod.txt))	
 	aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 202758212688.dkr.ecr.us-east-2.amazonaws.com
 	docker build -t massenergize/api .
@@ -29,14 +28,14 @@ deploy-prod:
 
 	git tag prod@$(VERSION)
 	git push origin prod@$(VERSION)
-.PHONY: deploy-prod
+.PHONY: build-and-push-prod
 
-prepare-canary:
-	python3 deployment/prepare_to_deploy.py --canary 0 1
-.PHONY: prepare-canary
+#prepare-canary:
+#	python3 deployment/prepare_to_deploy.py --canary 0 1
+#.PHONY: prepare-canary
 
 CANARY_VERSION=latest
-deploy-canary:
+build-and-push-canary:
 	$(eval CANARY_VERSION := $(shell cat api_version_canary.txt))	
 	aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 202758212688.dkr.ecr.us-east-2.amazonaws.com
 	docker build -t massenergize/api-canary .
@@ -46,14 +45,14 @@ deploy-canary:
 
 	git tag prod@$(CANARY_VERSION)
 	git push origin prod@$(CANARY_VERSION)
-.PHONY: deploy-canary
+.PHONY: build-and-deploy-canary
 
-prepare-dev:
-	python3 deployment/prepare_to_deploy.py --dev 0 1
-.PHONY: deploy-dev
+#prepare-dev:
+#	python3 deployment/prepare_to_deploy.py --dev 0 1
+#.PHONY: deploy-dev
 
 DEV_VERSION=latest
-deploy-dev:
+build-and-push-dev:
 	$(eval DEV_VERSION := $(shell cat api_version_dev.txt))	
 	aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 202758212688.dkr.ecr.us-east-2.amazonaws.com
 	docker build -t massenergize/api-dev .
@@ -63,7 +62,7 @@ deploy-dev:
 
 	git tag prod@$(DEV_VERSION)
 	git push origin prod@$(DEV_VERSION)
-.PHONY: deploy-dev
+.PHONY: build-and-push-dev
 
 deploy:
 	python3 deployment/prepare_to_deploy.py --dev
@@ -111,20 +110,20 @@ beat-remote:
 
 
 #-------------- NEW DEPLOYMENT STRATEGY ----------------
-serve-dev:
-	DJANGO_ENV=dev make prepare-dev
-    DJANGO_ENV=dev make deploy-dev
-.PHONY: serve-dev
+deploy-dev:
+	DJANGO_ENV=dev python3 deployment/prepare_to_deploy.py --dev 0 1
+    DJANGO_ENV=dev make build-and-push-dev
+.PHONY: deploy-dev
 
-serve-canary:
-	DJANGO_ENV=canary make prepare-canary
-	DJANGO_ENV=canary make deploy-canary
-.PHONY: serve-canary
+deploy-canary:
+	DJANGO_ENV=canary python3 deployment/prepare_to_deploy.py --canary 0 1
+	DJANGO_ENV=canary make build-and-push-canary
+.PHONY: deploy-canary
 
-serve-prod:
-	DJANGO_ENV=prod make prepare-canary
-	DJANGO_ENV=prod make deploy-canary
-.PHONY: serve-prod
+deploy-prod:
+	DJANGO_ENV=prod python3 deployment/prepare_to_deploy.py --prod 0 1
+	DJANGO_ENV=prod make build-and-push-canary
+.PHONY: deploy-prod
 
 #-------------- NEW  MIGRATE ----------------
 migrate-dev:

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,6 +26,9 @@ deploy-prod:
 	docker tag massenergize/api:latest 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api:$(VERSION)
 	docker push 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api:$(VERSION)
 	eb deploy --label $(VERSION)
+
+	git tag prod@$(VERSION)
+	git push origin prod@$(VERSION)
 .PHONY: deploy-prod
 
 prepare-canary:
@@ -40,6 +43,9 @@ deploy-canary:
 	docker tag massenergize/api-canary:latest 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api-canary:$(CANARY_VERSION)
 	docker push 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api-canary:$(CANARY_VERSION)
 	eb deploy --label $(CANARY_VERSION)
+
+	git tag prod@$(CANARY_VERSION)
+	git push origin prod@$(CANARY_VERSION)
 .PHONY: deploy-canary
 
 prepare-dev:
@@ -54,6 +60,9 @@ deploy-dev:
 	docker tag massenergize/api-dev:latest 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api-dev:$(DEV_VERSION)
 	docker push 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api-dev:$(DEV_VERSION)
 	eb deploy --label $(DEV_VERSION)
+
+	git tag prod@$(DEV_VERSION)
+	git push origin prod@$(DEV_VERSION)
 .PHONY: deploy-dev
 
 deploy:
@@ -61,11 +70,6 @@ deploy:
 	docker-compose build
 	docker-compose push
 .PHONY: deploy
-
-.PHONY: migrations
-migrations: 
-	python3 manage.py makemigrations
-	python3 manage.py migrate
 
 # Default: test api routes
 package=api
@@ -106,10 +110,35 @@ beat-remote:
 	celery -A _main_.celery.app beat -l info
 
 
-migrate:
-	python manage.py makemigrations
-	python manage.py migrate
+#-------------- NEW DEPLOYMENT STRATEGY ----------------
+serve-dev:
+	DJANGO_ENV=dev make prepare-dev
+    DJANGO_ENV=dev make deploy-dev
+.PHONY: serve-dev
+
+serve-canary:
+	DJANGO_ENV=canary make prepare-canary
+	DJANGO_ENV=canary make deploy-canary
+.PHONY: serve-canary
+
+serve-prod:
+	DJANGO_ENV=prod make prepare-canary
+	DJANGO_ENV=prod make deploy-canary
+.PHONY: serve-prod
+
+#-------------- NEW  MIGRATE ----------------
+migrate-dev:
+	DJANGO_ENV=dev python manage.py migrate
+.PHONY: migrate-dev
+
+migrate-prod:
+	DJANGO_ENV=prod python manage.py migrate
+.PHONY: migrate-prod
+
+migrate-canary:
+	DJANGO_ENV=canary python manage.py migrate
+.PHONY: migrate-canary
 
 migrate-local:
-	DJANGO_ENV=local python manage.py makemigrations
 	DJANGO_ENV=local python manage.py migrate
+.PHONY: migrate-local

--- a/src/_main_/settings.py
+++ b/src/_main_/settings.py
@@ -30,9 +30,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DJANGO_ENV = os.environ.get("DJANGO_ENV","remote")
 
 # Database selection, development DB unless one of these chosen
-IS_PROD = False
-IS_CANARY = False
-IS_LOCAL = False
+IS_PROD = DJANGO_ENV == "prod"
+IS_CANARY = DJANGO_ENV == "canary"
+IS_LOCAL = DJANGO_ENV == "local"
 
 RUN_SERVER_LOCALLY = IS_LOCAL
 RUN_CELERY_LOCALLY = IS_LOCAL


### PR DESCRIPTION
####  Summary / Highlights
This update implements a refined deployment strategy in the Makefile, that includes the tagging and deploying of production, canary, and dev versions. It also introduces separate, environment-specific migration commands for robust environment management. Complementary alterations have been made in settings.py to correctly identify the associated environments.


#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
