### PR TITLE
Speed up community portal loading: several changes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,11 +6,11 @@ init:
 .PHONY: init
 
 # run this with 'make start env=local'
-env=remote
+env=local
 export DJANGO_ENV=$(env)
 start:
-	DJANGO_ENV=local python3 deployment/prepare_to_deploy.py local 1
-	DJANGO_ENV=local python3 manage.py runserver
+	python3 deployment/prepare_to_deploy.py local 1
+	python3 manage.py runserver
 .PHONY: start
 
 #prepare-prod:

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -24,7 +24,6 @@ import calendar
 import pytz
 from typing import Tuple
 
-
 def _local_datetime(date_and_time):
     # the local date (in Massachusetts) is different than the UTC date
     # need to also save the location (as a Location) and get the time zone from that.
@@ -216,21 +215,28 @@ class EventStore:
         subdomain = args.pop("subdomain", None)
         user_id = args.pop("user_id", None)
         shared = []
+
+        today = datetime.datetime.now()
+        shared_months = 2
+        hosted_months = 6
+        earliest_shared = today - timedelta(weeks=4*shared_months)
+        earliest_hosted = today - timedelta(weeks=4*hosted_months)
+
         if community_id:
             # TODO: also account for communities who are added as invited_communities
-            events = Event.objects.select_related('image', 'community').prefetch_related('tags','invited_communities').filter(community__id=community_id)
+            events = Event.objects.select_related('image', 'community').prefetch_related('tags','invited_communities').filter(community__id=community_id, start_date_and_time__gte=earliest_hosted)
 
             # Find events that have been shared to this community
             community = Community.objects.get(pk=community_id)
 
             if community:
-                shared = community.events_from_others.filter(is_published=True)
+                shared = community.events_from_others.filter(is_published=True, start_date_and_time__gte=earliest_shared)
 
         elif subdomain:
-            events = Event.objects.select_related('image', 'community').prefetch_related('tags','invited_communities').filter(community__id=community_id)
+            events = Event.objects.select_related('image', 'community').prefetch_related('tags','invited_communities').filter(community__id=community_id, start_date_and_time__gte=earliest_hosted)
             community = Community.objects.get(subdomain=subdomain)
 
-            if community: shared = community.events_from_others.filter(is_published=True)
+            if community: shared = community.events_from_others.filter(is_published=True, start_date_and_time__gte=earliest_shared)
 
 
         elif user_id:
@@ -646,15 +652,15 @@ class EventStore:
             # TODO: also account for communities who are added as invited_communities
             query = Q(community__id=community_id)
             events = Event.objects.select_related('image', 'community').prefetch_related('tags',
-                                                                                         'invited_communities').filter(
-                query, is_published=True, is_deleted=False)
+                                                                                         'shared_to').filter(
+                query, is_published=True, is_recurring=True, is_deleted=False)
 
         elif subdomain:
             # testing only
             query = Q(community__subdomain=subdomain)
             events = Event.objects.select_related('image', 'community').prefetch_related('tags',
-                                                                                         'invited_communities').filter(
-                query, is_published=True, is_deleted=False)
+                                                                                         'shared_to').filter(
+                query, is_published=True, is_recurring=True, is_deleted=False)
 
 
         elif user_id:
@@ -740,7 +746,7 @@ class EventStore:
             except Exception as e:
                 print(str(e))
                 return CustomMassenergizeError(e)
-        return events, None
+        return None, None
 
     def rank_event(self, args, context: Context) -> Tuple[dict, MassEnergizeAPIError]:
         try:

--- a/src/api/store/page_settings__home.py
+++ b/src/api/store/page_settings__home.py
@@ -7,6 +7,7 @@ from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
 from sentry_sdk import capture_message
 from typing import Tuple
+import time
 
 class HomePageSettingsStore:
   def __init__(self):
@@ -14,8 +15,14 @@ class HomePageSettingsStore:
 
   def get_home_page_setting_info(self,context, args) -> Tuple[dict, MassEnergizeAPIError]:
     try:
+      time1 = time.time()
       args['community'] = get_community_or_die(context, args)
-      home_page_setting = HomePageSettings.objects.filter(**args).first()
+      time2 = time.time()
+      print(time2-time1)
+      home_page_setting = HomePageSettings.objects.filter(**args).prefetch_related('images').first()
+      #home_page_setting = HomePageSettings.objects.get(id=community.id).prefetch_related('images').first()
+      time3 = time.time()
+      print(time3-time2)
       if not home_page_setting:
         return None, InvalidResourceError()
       return home_page_setting, None

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -18,7 +18,6 @@ from database.utils.settings.user_settings import UserPortalSettings
 from django.utils import timezone
 from django.core.files.storage import default_storage
 from django.db.models.query import QuerySet
-import time
 
 from .utils.common import (
     get_images_in_sequence,
@@ -2178,44 +2177,22 @@ class Event(models.Model):
                 "shared_to",
             ],
         )
-        time1 = time.time()
         data["tags"] = [t.info() for t in self.tags.all()]
-        time2 = time.time()
         data["community"] = None if not self.community else self.community.info()
-        time3 = time.time()
         data["image"] = None if not self.image else self.image.info()
-        time4 = time.time()
-        data["invited_communities"] = [ c.info() for c in self.invited_communities.all()]
-        time5 = time.time()
+        #data["invited_communities"] = [ c.info() for c in self.invited_communities.all()]
         data["is_open"] =  False if not self.publicity else EventConstants.is_open(self.publicity)
-        time6 = time.time()
         data["is_open_to"] = False if not self.publicity else EventConstants.is_open_to(self.publicity)
-        time7 = time.time()
         data["is_closed_to"] = False if not self.publicity else EventConstants.is_closed_to(self.publicity)
-        time8 = time.time()
         data["communities_under_publicity"] = [c.info() for c in self.communities_under_publicity.all()]
-        time9 = time.time()
 
         if self.user:
             data["user_email"] = self.user.email
-        time10 = time.time()
 
         data["shared_to"] = [c.info() for c in self.shared_to.all()]
         data["is_on_home_page"] = self.is_on_homepage()
-        time11 = time.time()
 
         data["event_type"] = self.event_type if self.event_type else "Online" if not self.location else "In person"
-#        data["settings"] = dict(notifications=[x.simple_json() for x in self.nudge_settings.all().order_by("-created_at") if x.communities.exists()])
-        print("2-1", time2 - time1)
-        print("3-1", time3 - time2)
-        print("4-1", time4 - time3)
-        print("5-1", time5 - time4)
-        print("6-1", time6 - time5)
-        print("7-1", time7 - time6)
-        print("8-1", time8 - time7)
-        print("9-1", time9 - time8)
-        print("10-1", time10 - time9)
-        print("11-1", time11 - time10)
 
         return data
 
@@ -3338,11 +3315,7 @@ class HomePageSettings(models.Model):
         return res
 
     def full_json(self):
-        time1 = time.time()
-        # <1ms
         res = self.simple_json()
-        time2 = time.time()
-        # 10 ms
         images = self.images.all()
         sequence = self.image_sequence.sequence if self.image_sequence else None
         res["images"] = (
@@ -3350,19 +3323,9 @@ class HomePageSettings(models.Model):
             if sequence
             else [i.simple_json() for i in images]
         )
-        # 50 ms
         # res["community"] = get_json_if_not_none(self.community)
-        time3 = time.time()
-        # 68 ms
         res["featured_events"] = [i.simple_json() for i in self.featured_events.all()]
-        time4 = time.time()
-        # 2 ms
         res["featured_stats"] = [i.simple_json() for i in self.featured_stats.all()]
-        time5 = time.time()
-        print(time2-time1)
-        print(time3-time2)
-        print(time4-time3)
-        print(time5-time4)
         return res
 
     class Meta:

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -1516,7 +1516,7 @@ class Team(models.Model):
         Community, related_name="primary_community_teams", on_delete=models.CASCADE
     )
     images = models.ManyToManyField(
-        Media, related_name="teams", blank=True
+        Media, related_name="teams"
     )  # 0 or more photos - could be a slide show
     video_link = models.CharField(
         max_length=LONG_STR_LEN, blank=True
@@ -1528,7 +1528,7 @@ class Team(models.Model):
         blank=True, null=True
     )  # settable team page options
     parent = models.ForeignKey(
-        "self", null=True, blank=True, on_delete=models.SET_NULL
+        "self", null=True, on_delete=models.SET_NULL
     )  # for the case of sub-teams
 
     goal = models.ForeignKey(Goal, blank=True, null=True, on_delete=models.SET_NULL)


### PR DESCRIPTION
####  Summary / Highlights
This PR addresses issue #932 to speed up community portal loading, especially for the events or actions page directly by a factor of two or more.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
The time for loading pages is determined by the slowest routes, which were events.list and testimonials.list.
These times are dominated by the serialization of events and testimonials.

For events, we were listing all hosted and shared events from the beginining of time.  
The list_event routine now limits shared event to be from 2 months ago to the future, and hosted events from  6 months ago to the future.

Additionally, we do not prefetch invited_communities which is a field not used, but do prefetch shared_to

Also events.update_date for updating the date on recurring events filters on recurring events, and more importantly, does not return the events list but returns None (preventing serialization of all hosted events).

No database migrations are needed.

#### Testing Steps (Provide details on how your changes can be tested)
Test the timeing in dev and canary before and after this change

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
