### PR TITLE
:recycle: Update column headers in campaign interaction download 

### DIFF
--- a/src/api/store/download.py
+++ b/src/api/store/download.py
@@ -1799,15 +1799,17 @@ class DownloadStore:
 
 
     def _campaign_interaction_performance_download(self, campaign):
-        columns = ["Date", "Campaign", "Email",  "Action", "Target"]
+        columns = ["Date", "Email",  "Source", "Element", "Target"]
         data = [columns]
         interactions = CampaignActivityTracking.objects.filter(campaign__id=campaign.id, is_deleted=False)
         for interaction in interactions:
             cell  = self._get_cells_from_dict(columns,{
                 "Date": get_human_readable_date(interaction.created_at),
-                "Action": interaction.source,
+                "Source": interaction.source,
                 "Email": interaction.email,
                 "Target": interaction.target,
+                "Element": interaction.button_type
+                
             })
             data.append(cell)
         return data


### PR DESCRIPTION
####  Summary / Highlights
This pull request updates the column headers for the "_campaign_interaction_performance_download" method. Previously, the column headers were labeled as "Campaign" and "Action", but these have been updated to "Source" and "Element". A new column, "Element", has been added to provide information about the button type of the interaction

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
