### PR TITLE
948 - return community summary info with PageSettings

### DIFF
--- a/src/api/store/page_settings__home.py
+++ b/src/api/store/page_settings__home.py
@@ -7,7 +7,6 @@ from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
 from sentry_sdk import capture_message
 from typing import Tuple
-import time
 
 class HomePageSettingsStore:
   def __init__(self):
@@ -15,14 +14,8 @@ class HomePageSettingsStore:
 
   def get_home_page_setting_info(self,context, args) -> Tuple[dict, MassEnergizeAPIError]:
     try:
-      time1 = time.time()
       args['community'] = get_community_or_die(context, args)
-      time2 = time.time()
-      print(time2-time1)
       home_page_setting = HomePageSettings.objects.filter(**args).prefetch_related('images').first()
-      #home_page_setting = HomePageSettings.objects.get(id=community.id).prefetch_related('images').first()
-      time3 = time.time()
-      print(time3-time2)
       if not home_page_setting:
         return None, InvalidResourceError()
       return home_page_setting, None

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -3198,7 +3198,7 @@ class PageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3324,7 +3324,7 @@ class HomePageSettings(models.Model):
             if sequence
             else [i.simple_json() for i in images]
         )
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         res["featured_events"] = [i.simple_json() for i in self.featured_events.all()]
         res["featured_stats"] = [i.simple_json() for i in self.featured_stats.all()]
         return res
@@ -3359,7 +3359,7 @@ class ActionsPageSettings(models.Model):
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
         # next line is most of the time (54ms on local)
-        #res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3399,7 +3399,7 @@ class ContactUsPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3443,7 +3443,7 @@ class DonatePageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3484,7 +3484,7 @@ class AboutUsPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3525,7 +3525,7 @@ class ImpactPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):


### PR DESCRIPTION
####  Summary / Highlights
Fixes Edit xxx Page Settings titles on Admin portal.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
This PR addresses issue #948 
A bug I introduced last week caused a cosmetic issue the Admin Portal pages to edit PageSetting.
Add back in the community summary info with the page_settings response

#### Testing Steps (Provide details on how your changes can be tested)
I've tested it locally with the admin portal by editing each page settings.  This is done from the Community Profile page, choosing the Pages tab, and selecting each of the pages to edit.

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [x] I moved the linked issue to "Local Testing" now that it is ready to merge.
