### PR TITLE
Fix: Display Full Event List on Community Portal

### DIFF
--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -233,8 +233,9 @@ class EventStore:
                 shared = community.events_from_others.filter(is_published=True, start_date_and_time__gte=earliest_shared)
 
         elif subdomain:
-            events = Event.objects.select_related('image', 'community').prefetch_related('tags','invited_communities').filter(community__id=community_id, start_date_and_time__gte=earliest_hosted)
             community = Community.objects.get(subdomain=subdomain)
+            events = Event.objects.select_related('image', 'community').prefetch_related('tags','invited_communities').filter(community__id=community.id, start_date_and_time__gte=earliest_hosted)
+            
 
             if community: shared = community.events_from_others.filter(is_published=True, start_date_and_time__gte=earliest_shared)
 


### PR DESCRIPTION
####  Summary / Highlights
This pull request addresses and resolves a bug that was causing the events list on the community portal to be truncated. The root cause of this issue was a faulty query that attempted to retrieve events for a community using a null community_id. The solution implemented corrects this by utilizing the community's subdomain for event retrieval instead of the community_id.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
