### PR TITLE
Prod fix for community logo and events missing

### DIFF
--- a/src/database/models.py
+++ b/src/database/models.py
@@ -3198,7 +3198,7 @@ class PageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3311,8 +3311,9 @@ class HomePageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(
-            self, exclude=["images", "featured_events", "featured_stats"]
+            self, exclude=["images", "featured_events", "featured_stats", "community"]
         )
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3358,8 +3359,7 @@ class ActionsPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # next line is most of the time (54ms on local)
-        #res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3399,7 +3399,7 @@ class ContactUsPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3443,7 +3443,7 @@ class DonatePageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3484,7 +3484,7 @@ class AboutUsPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):
@@ -3525,7 +3525,7 @@ class ImpactPageSettings(models.Model):
 
     def simple_json(self):
         res = model_to_dict(self, exclude=["images"])
-        # res["community"] = get_json_if_not_none(self.community)
+        res["community"] = get_summary_info(self.community)
         return res
 
     def full_json(self):


### PR DESCRIPTION
####  Summary / Highlights
This PR duplicates #948 which will fix the missing logos (issue #954):
1. Logos are missing from community sites
2. Events on events page all listed as "SHARED"

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
These bugs would also be fixed by merging dev -> canary -> prod, but if the testing for this woudl take a couple extra days you can merge and deploy this PR.

Tahiru's PR 952 to fix Events is probably not required, as the bug he was fixing is gone with this PR

No migrations are required.

#### Testing Steps (Provide details on how your changes can be tested)
Check that the community site logos come back when this is deployed
Check that the Events are not all listed as SHARED, but only the ones shared from other communities.

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [x] I moved the linked issue to "QA Verification" now that it is ready to merge.
