### PR TITLE
Hotfix: Rollback of Feature Flags Fetching Endpoint

### DIFF
--- a/src/api/handlers/community.py
+++ b/src/api/handlers/community.py
@@ -40,8 +40,9 @@ class CommunityHandler(RouteHandler):
     self.add("/communities.listForSuperAdmin", self.super_admin_list)
     self.add("/communities.adminsOf", self.fetch_admins_of)
     self.add("/communities.features.list", self.list_community_features) # list features community admins can opt into
-    self.add("/communities.features.flags.list", self.list_communities_feature_flags) # list all feature flags open to a community
+
     self.add("/communities.features.request", self.request_feature_for_community)
+    # self.add("/communities.features.flags.list", self.list_communities_feature_flags) # list all feature flags open to a community
 
   def info(self, request):
     context: Context = request.context

--- a/src/api/handlers/community.py
+++ b/src/api/handlers/community.py
@@ -42,7 +42,7 @@ class CommunityHandler(RouteHandler):
     self.add("/communities.features.list", self.list_community_features) # list features community admins can opt into
 
     self.add("/communities.features.request", self.request_feature_for_community)
-    # self.add("/communities.features.flags.list", self.list_communities_feature_flags) # list all feature flags open to a community
+    self.add("/communities.features.flags.list", self.list_communities_feature_flags) # list all feature flags open to a community
 
   def info(self, request):
     context: Context = request.context

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -590,7 +590,7 @@ class Community(models.Model):
         res["logo"] = get_json_if_not_none(self.logo)
         res["favicon"] = get_json_if_not_none(self.favicon)
         # this will not slow it down measurably
-        # res["feature_flags"] = get_enabled_flags(self)
+        res["feature_flags"] = get_enabled_flags(self)
         return res
 
     # def medium_json(self):
@@ -744,7 +744,7 @@ class Community(models.Model):
             "admins": admins,
             "geography_type": self.geography_type,
             "locations": locations,
-            # "feature_flags": get_enabled_flags(self),
+            "feature_flags": get_enabled_flags(self),
             "is_demo": self.is_demo,
             "contact_sender_alias": self.contact_sender_alias,
         }


### PR DESCRIPTION
####  Summary / Highlights
This pull request addresses the recent changes made to the endpoint for fetching feature flags for communities. Previously, the endpoint was modified to fetch feature flags directly, but this has been rolled back to the original implementation where feature flags are accessed from the community object.
#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
