### PR TITLE
Fix: create new  EventNudgeSetting if doent exist when sending Nudges

### DIFF
--- a/src/task_queue/nudges/user_event_nudge.py
+++ b/src/task_queue/nudges/user_event_nudge.py
@@ -8,7 +8,7 @@ from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
 from api.utils.api_utils import get_sender_email
 from api.utils.constants import USER_EVENTS_NUDGE_TEMPLATE
-from database.models import Community, CommunityMember, CommunityNotificationSetting, Event, UserProfile, FeatureFlag
+from database.models import Community, CommunityMember, CommunityNotificationSetting, Event, UserProfile, FeatureFlag, EventNudgeSetting
 from django.db.models import Q
 from dateutil.relativedelta import relativedelta
 from database.utils.common import get_json_if_not_none
@@ -109,6 +109,10 @@ def update_last_notification_dates(email):
 def is_event_eligible(event, community_id, task=None):
     now = timezone.now()
     settings = event.nudge_settings.filter(communities__id=community_id).first()
+
+    # it it doesn't exist, then create, don't save an instance of NudgeSettings
+    if not settings:
+        settings = EventNudgeSetting.objects.create(event=event, **DEFAULT_EVENT_SETTINGS)
 
     if settings.never:
         return False

--- a/src/task_queue/nudges/user_event_nudge.py
+++ b/src/task_queue/nudges/user_event_nudge.py
@@ -113,6 +113,7 @@ def is_event_eligible(event, community_id, task=None):
     # it it doesn't exist, then create, don't save an instance of NudgeSettings
     if not settings:
         settings = EventNudgeSetting.objects.create(event=event, **DEFAULT_EVENT_SETTINGS)
+        settings.communities.add(community_id)
 
     if settings.never:
         return False


### PR DESCRIPTION
####  Summary / Highlights

This PR addresses the issue of missing EventNudgeSetting instances when sending nudges. Previously, if an EventNudgeSetting did not exist for a particular event, the system would fail to send a nudge for that event. This fix ensures that a new EventNudgeSetting is created with default settings if one does not already exist, allowing the nudge to be sent as expected.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
