### PR TITLE
966 - fix Cadmin Event Sharing nudge

### DIFF
--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -179,7 +179,7 @@ def prepare_events_email_data(events):
 def send_events_nudge(task=None):
     try:
         admins_emailed=[]
-        flag = FeatureFlag.objects.get(key=WEEKLY_EVENT_NUDGE)
+        flag = FeatureFlag.objects.get(key=COMMUNITY_ADMIN_WEEKLY_EVENTS_NUDGE_FF)
         if not flag or not flag.enabled():
             return False
 


### PR DESCRIPTION
Fixes an exception in the Cadmin weekly event sharing nudge due to a variable being renamed.

Please test this and get it into canary and prod ASAP.  Thanks