### PR TITLE
Fix Celery task executing in multiple instances

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -139,3 +139,7 @@ migrate-canary:
 migrate-local:
 	DJANGO_ENV=local python manage.py migrate
 .PHONY: migrate-local
+
+
+create-cache-table-local:
+	DJANGO_ENV=local python manage.py createcachetable

--- a/src/_main_/settings.py
+++ b/src/_main_/settings.py
@@ -31,7 +31,7 @@ DJANGO_ENV = os.environ.get("DJANGO_ENV","remote")
 
 # Database selection, development DB unless one of these chosen
 IS_PROD = False
-IS_CANARY = True
+IS_CANARY = False
 IS_LOCAL = False
 
 RUN_SERVER_LOCALLY = IS_LOCAL
@@ -206,6 +206,13 @@ if is_test_mode():
 #         'LOCATION': os.getenv('CACHE_LOCATION'),
 #     }
 # }
+
+CACHES = {
+    'default': {
+            'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+            'LOCATION': 'cache_table'
+        }
+}
 
 # url and hosts config
 ROOT_URLCONF = '_main_.urls'

--- a/src/_main_/utils/route_handler/__init__.py
+++ b/src/_main_/utils/route_handler/__init__.py
@@ -1,6 +1,5 @@
 from types import FunctionType as function
 from django.urls import path, re_path
-from django.conf.urls import url
 from _main_.utils.validator import Validator
 
 class RouteHandler:

--- a/src/task_queue/tasks.py
+++ b/src/task_queue/tasks.py
@@ -6,19 +6,24 @@ from task_queue.helpers import is_time_to_run
 from .jobs import FUNCTIONS
 from api.services.utils import send_slack_message
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, IS_PROD, IS_LOCAL, IS_CANARY
+from django.core.cache import cache
 
 ENV = "API Local" if IS_LOCAL else "API CANARY" if IS_CANARY else "API PROD" if IS_PROD else "API DEV"
 
 
-@shared_task(bind=True, autoretry_for=(Exception,), retry_kwargs={'max_retries': 1, 'countdown': 5})
+@shared_task(bind=True, autoretry_for=(Exception,), retry_kwargs={'max_retries': 1, 'countdown': 5}, acks_late=True)
 def run_some_task(self, task_id):
+    
+    lock_id = f'task_lock_{task_id}'
+    
+    if not cache.set(lock_id, 'true', 60):
+        return
     try:
         today = datetime.date.today()
         should_run = False
         task = None
         with transaction.atomic():
-            task = Task.objects.select_for_update().get(
-                id=task_id)  # locks task instance until transaction is committed
+            task = Task.objects.select_for_update().get(id=task_id)  # locks task instance until transaction is committed
             if is_time_to_run(task):
                 task.last_run = today
                 task.save()
@@ -50,3 +55,5 @@ def run_some_task(self, task_id):
         if IS_PROD:
             send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {
                 "text": f"({ENV}): Task '{task.job_name}' was run on {today}. Status: FAILED. Reason: {str(e)} "})
+    finally:
+        cache.delete(lock_id)

--- a/src/task_queue/tasks.py
+++ b/src/task_queue/tasks.py
@@ -15,9 +15,13 @@ ENV = "API Local" if IS_LOCAL else "API CANARY" if IS_CANARY else "API PROD" if 
 def run_some_task(self, task_id):
     
     lock_id = f'task_lock_{task_id}'
+    cached_lock = cache.get(lock_id)
     
-    if not cache.set(lock_id, 'true', 60):
+    if cached_lock:
         return
+    
+    cache.set(lock_id, True)
+    
     try:
         today = datetime.date.today()
         should_run = False


### PR DESCRIPTION
####  Summary / Highlights
This pull request tries to fix celery tasks executing on multiple instances by using django cache as a locking mechanism.
#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
