### PR TITLE
Fix: Addition of Check for Community Selection in Campaign Subscription

### DIFF
--- a/src/api/store/campaign.py
+++ b/src/api/store/campaign.py
@@ -898,6 +898,9 @@ class CampaignStore:
 
             if not campaign_id:
                 return None, CustomMassenergizeError("Campaign id not found!")
+            
+            if not community_id and not is_other:
+                return None, CustomMassenergizeError("Please select a community!")
 
             campaign = Campaign.objects.filter(id=campaign_id).first()
             if not campaign:


### PR DESCRIPTION
####  Summary / Highlights
This pull request introduces a check in the campaign API to verify if a 'community_id' is provided during campaign subscription.

https://github.com/massenergize/api/assets/42780120/4975ad19-0497-4827-8215-68ce77bd5665


#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
