### PR TITLE
Fix: Add task locking to isolated celery tasks

### DIFF
--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -393,34 +393,43 @@ class MessageStore:
                 messages = Message.objects.filter(pk=message_id)
                 if not messages.first():
                     return None, InvalidResourceError()
-                # revoke the previous task
+                
                 message_schedule_info = messages.first().schedule_info or {}
                 task_id = message_schedule_info.get("schedule_id", None)
+                
                 if task_id:
                     result = AsyncResult(task_id)
                     result.revoke()
-                # schedule new task and update message
+                    
                 scheduled_at =messages.first().scheduled_at
 
                 if messages.first().scheduled_at != schedule:
                    scheduled_at = schedule
                 
                 schedule_id = send_scheduled_email.apply_async(args=[ subject,message,email_list, logo],eta=schedule,retry=False)
+                
                 schedule_info ={} if not args.get("schedule", None) else {"schedule_id": schedule_id.id if schedule_id else None,"recipients":{"audience_type":audience_type, "audience":audience, "sub_audience_type":sub_audience_type, "community_ids":communities}}
+                
                 messages.update(**{"schedule_info": schedule_info, "body": message, "title": subject, "scheduled_at":scheduled_at, "community":associated_community })
+                
                 return messages.first(), None
+            
             else:
                 schedule_id = send_scheduled_email.apply_async(args=[ subject,message,email_list, logo],eta=schedule,retry=False)
+                
                 new_message = Message(
-                title=subject,
-                body=message,
-                user=user,
-                scheduled_at= schedule,
-                schedule_info = {} if not args.get("schedule", None) else {"schedule_id": schedule_id.id if schedule_id else None, "recipients":{"audience_type":audience_type, "audience":audience, "sub_audience_type":sub_audience_type, "community_ids":communities}},
-                community=associated_community
+                    title=subject,
+                    body=message,
+                    user=user,
+                    scheduled_at= schedule,
+                    schedule_info = {} if not args.get("schedule", None) else {"schedule_id": schedule_id.id if schedule_id else None, "recipients":{"audience_type":audience_type, "audience":audience, "sub_audience_type":sub_audience_type, "community_ids":communities}},
+                    community=associated_community
                 )
+                
                 new_message.save()
+                
                 return new_message, None
+            
         except Exception as e:
             capture_message(str(e), level="error")
             return None, CustomMassenergizeError(e)

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -405,12 +405,12 @@ class MessageStore:
                 if messages.first().scheduled_at != schedule:
                    scheduled_at = schedule
                 
-                schedule_id = send_scheduled_email.apply_async(args=[ subject,message,email_list, logo],eta=schedule)
+                schedule_id = send_scheduled_email.apply_async(args=[ subject,message,email_list, logo],eta=schedule,retry=False)
                 schedule_info ={} if not args.get("schedule", None) else {"schedule_id": schedule_id.id if schedule_id else None,"recipients":{"audience_type":audience_type, "audience":audience, "sub_audience_type":sub_audience_type, "community_ids":communities}}
                 messages.update(**{"schedule_info": schedule_info, "body": message, "title": subject, "scheduled_at":scheduled_at, "community":associated_community })
                 return messages.first(), None
             else:
-                schedule_id = send_scheduled_email.apply_async(args=[ subject,message,email_list, logo],eta=schedule)
+                schedule_id = send_scheduled_email.apply_async(args=[ subject,message,email_list, logo],eta=schedule,retry=False)
                 new_message = Message(
                 title=subject,
                 body=message,

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -24,7 +24,7 @@ from database.models import Community, CommunityAdminGroup, CommunityMember, Com
 from task_queue.nudges.cadmin_events_nudge import generate_event_list_for_community, send_events_report
 from task_queue.nudges.user_event_nudge import prepare_user_events_nudge
 from django.core.cache import cache
-
+from _main_.celery.app import app
 def generate_csv_and_email(data, download_type, community_name=None, email=None,filename=None):
     response = HttpResponse(content_type="text/csv")
     now = datetime.datetime.now().strftime("%Y%m%d")
@@ -284,51 +284,55 @@ def deactivate_user(self,email):
     if user:
         user.delete()
 
-@shared_task(bind=True)
-def send_scheduled_email(self,subject, message, recipients, image):
-    cache_key =f"email_sent_{subject.replace(' ', '_')}"
-    is_running = cache.get(cache_key)
-    if is_running:
-        logging.info("Task already picked up by another worker")
-        return
-    cache.set(cache_key, True)
-    try:
-        data = {
-           "body": message,
-           "subject": subject,
-           "image":image
-        }
-        is_sent = send_massenergize_email_with_attachments(BROADCAST_EMAIL_TEMPLATE, data, recipients, None, None)
-        if is_sent:
-            logging.info(f"Successfully sent email to {str(recipients)}")
 
-    except Exception as e:
-        logging.error(f"Error sending email: {str(e)}")
+@app.task
+def send_scheduled_email(subject, message, recipients, image):
+    cache_key = f"email_sent_{subject.replace(' ', '_')}"
+    
+    if cache.add(cache_key, True, timeout=3600):
         
-    finally:
-        cache.delete(cache_key)
-        
-@shared_task(bind=True)
-def automatically_activate_nudge(self,community_nudge_setting_id):
-    cache_key =f"nudge_activated_{community_nudge_setting_id}"
-    is_running = cache.get(cache_key)
-    if is_running:
+        try:
+            data = {"body": message, "subject": subject, "image": image}
+            
+            is_sent = send_massenergize_email_with_attachments(BROADCAST_EMAIL_TEMPLATE, data, recipients, None, None)
+            
+            if is_sent:
+                logging.info(f"Successfully sent email to {str(recipients)}")
+                
+        except Exception as e:
+            logging.error(f"Error sending email: {str(e)}")
+            
+        finally:
+            logging.info(f"===== Deleting Cache Key: {cache_key} =====")
+            cache.delete(cache_key)
+            
+    else:
         logging.info("Task already picked up by another worker")
-        return
-    cache.set(cache_key, True)
-    try:
-        community_nudge_setting = CommunityNotificationSetting.objects.filter(id=community_nudge_setting_id).first()
-        if not community_nudge_setting:
-            return
-        community_nudge_setting.activate_on = None
-        community_nudge_setting.is_active = True
-        community_nudge_setting.save()
         
-        logging.info(f"Successfully activated nudge for community: {community_nudge_setting.community.name}")
+@app.task
+def automatically_activate_nudge(community_nudge_setting_id):
+    
+    cache_key =f"nudge_activation_{community_nudge_setting_id}"
+    
+    if cache.add(cache_key, True, timeout=3600):
         
-    except Exception as e:
-        logging.error(f"Error automatically activating nudge: {str(e)}")
-        
-    finally:
-        cache.delete(cache_key)
+        try:
+            community_nudge_setting = CommunityNotificationSetting.objects.filter(id=community_nudge_setting_id).first()
+            if not community_nudge_setting:
+                logging.error(f"Community Nudge Setting with id({community_nudge_setting_id}) not found")
+                return
+            community_nudge_setting.activate_on = None
+            community_nudge_setting.is_active = True
+            community_nudge_setting.save()
+            
+            logging.info(f"Successfully activated nudge for community: {community_nudge_setting.community.name}")
+            
+        except Exception as e:
+            logging.error(f"Error automatically activating nudge: {str(e)}")
+            
+        finally:
+            logging.info(f"===== Deleting Cache Key: {cache_key} =====")
+            cache.delete(cache_key)
+    else:
+        logging.info("Task already picked up by another worker")
     

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,23 +1,23 @@
-version: '3.8'
-
 services:
   app:
     build: .
     command: sh -c "python manage.py runserver 0.0.0.0:8000"
-    container_name: app
     ports:
       - "80:8000" # for deployed version
-      - "8000:8000" # for localhost testing
-    image: 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api-dev
+      - "8000:8000" # for local testing
+
+    image: massenergize/api
     restart: on-failure
+
 
   celery_worker:
     command: sh -c "celery -A _main_.celery.app worker -l info"
     depends_on:
       - app
     hostname: celery_worker
-    image: 202758212688.dkr.ecr.us-east-2.amazonaws.com/massenergize/api-dev
+    image: massenergize/api
     restart: on-failure
+
 
   celery_beat:
     command: sh -c "celery -A _main_.celery.app beat -l info"


### PR DESCRIPTION
####  Summary / Highlights
This pull request introduces a locking mechanism to tasks that run our bulk messaging and feature reactivate feature. This will prevent our tasks from executing multiple times when we have multiple instances running.
#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
