### PR TITLE
fix /health_check, /version and /home bug

### DIFF
--- a/src/api/handlers/misc.py
+++ b/src/api/handlers/misc.py
@@ -7,6 +7,7 @@ from _main_.utils.context import Context
 from api.decorators import admins_only, super_admins_only
 from database.utils.settings.admin_settings import AdminPortalSettings
 from database.utils.settings.user_settings import UserPortalSettings
+from django.http import JsonResponse
 
 
 class MiscellaneousHandler(RouteHandler):
@@ -144,12 +145,18 @@ class MiscellaneousHandler(RouteHandler):
 
     def health_check(self, request):
         context: Context = request.context
-        return self.service.health_check(context, request)
-
+        data, err = self.service.health_check(context)
+        if err:
+            return MassenergizeResponse(data=data, error=err)
+        return JsonResponse(data=data, safe=False)
 
     def version(self, request):
         context: Context = request.context
-        return self.service.version(context, request)
+        data, err = self.service.version(context, request)
+        if err:
+            return MassenergizeResponse(data=data, error=err)
+        return JsonResponse(data=data, safe=False)
+
 
     def authenticateFrontendInTestMode(self, request):
         context: Context = request.context

--- a/src/api/services/misc.py
+++ b/src/api/services/misc.py
@@ -90,13 +90,11 @@ class MiscellaneousService:
             },
         )
 
-    def health_check(self, ctx: Context, args):
-        #TODO: return the environment info: dev, canary, prod and then the git commit / tag and version info
+    def health_check(self, ctx: Context):
         return { "ok": True }, None
 
 
     def version(self, ctx: Context, args):
-        #TODO: return the environment info: dev, canary, prod and then the git commit / tag and version info
         return EnvConfig.release_info, None
 
     def create_carbon_equivalency(self, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/website/views.py
+++ b/src/website/views.py
@@ -932,11 +932,11 @@ def contact_us(request, subdomain=None):
     return render(request, "page__contact_us.html", args)
 
 def health_check(request):
-    return JsonResponse(data={"ok": True, "msg": "Thanks for coming.  I am doing really well. yay!"}, safe=False)
+    return MiscellaneousHandler().health_check(request)
 
 
 def version(request):
-    return JsonResponse(data=EnvConfig.release_info, safe=False)
+    return MiscellaneousHandler().version(request)
 
 
 def generate_sitemap(request):


### PR DESCRIPTION
####  Summary / Highlights
We were getting erros lilke:
```
[request_id=61ab6ec1-b3f3-46a8-a9ad-71cb8b806b80] 2024-05-31 12:19:23,290 ERROR django.request Internal Server Error: /health_check
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.9/site-packages/sentry_sdk/integrations/django/views.py", line 84, in sentry_wrapped_callback
    return callback(request, *args, **kwargs)
  File "/src/_main_/utils/metrics/__init__.py", line 21, in wrap
    return func(*args, **kwargs)
  File "/src/api/handlers/misc.py", line 146, in health_check
    return self.service.health_check(context, request)
TypeError: health_check() takes 2 positional arguments but 3 were given
```


#### Details (Give details about what this PR accomplishes, include any screenshots etc)
This PR fixes the above error and also streamlines calls to version, and health check
#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [x] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
