### PR TITLE
Fix: Custom Website Check for Community Site Menu Items

### DIFF
--- a/src/api/utils/api_utils.py
+++ b/src/api/utils/api_utils.py
@@ -104,35 +104,53 @@ def create_media_file(file, name):
 
 # -------------------------- Menu Utils --------------------------
 
+def has_no_custom_website(community):
+    if community.community_website and community.community_website.first() and community.community_website.first().website:
+        return False
+    return True
 
-def prepend_prefix_to_links(menu_item: object, prefix: object) -> object:
+
+def prepend_prefix_to_links(menu_item, prefix):
+  
     if not menu_item:
         return None
+    
     if "link" in menu_item:
         existing_link = menu_item["link"]
+        
         if existing_link.startswith("/"):
             existing_link = existing_link[1:]
-        menu_item["link"] = f"/{prefix}/{existing_link}"
+            
+        menu_item["link"] = f"{prefix}/{existing_link}"
+        
     if "children" in menu_item:
+        
         for child in menu_item["children"]:
             prepend_prefix_to_links(child, prefix)
+            
     return menu_item
 
 
 def modify_menu_items_if_published(menu_items, page_settings, prefix):
-    if not menu_items or not page_settings or not prefix:
+    
+    if not menu_items or not page_settings:
         return []
 
     main_menu = []
 
     for item in menu_items:
+        
         if not item.get("children"):
             name = item.get("link", "").strip("/")
+            
             if name in page_settings and not page_settings[name]:
                 main_menu.remove(item)
+                
         else:
+            
             for child in item["children"]:
                 name = child.get("link", "").strip("/")
+                
                 if name in page_settings and not page_settings[name]:
                     item["children"].remove(child)
 
@@ -168,12 +186,12 @@ def get_viable_menu_items(community):
         "testimonials": testimonial_page_settings.is_published,
         "teams": teams_page_settings.is_published,
         "events": events_page_settings.is_published,
-    }, community.subdomain)
+    },f'{"/"+community.subdomain if has_no_custom_website(community) else ""}')
 
     footer_menu_content = all_menu.get(name='PortalFooterQuickLinks')
 
     portal_footer_quick_links = [
-        {**item, "link": "/"+community.subdomain + "/" + item["link"]}
+        {**item, "link": f'{"/"+community.subdomain if has_no_custom_website(community) else ""}/{item["link"]}'}
         if not item.get("children") and item.get("navItemId", None) != "footer-report-a-bug-id"
         else item
         for item in footer_menu_content.content["links"]


### PR DESCRIPTION
####  Summary / Highlights
This PR addresses issues encountered with menu items on community sites that have a custom website. Specifically, when generating links for the menu items, we now include a condition to verify the presence of a custom website for the community. If a custom website is found, we refrain from prefixing the subdomain. This fix ensures accurate URL construction for menu items, enhancing the user experience on custom community sites.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
