### PR TITLE
Remove setupCC method from test files

### DIFF
--- a/src/api/tests/test_campaigns.py
+++ b/src/api/tests/test_campaigns.py
@@ -1,7 +1,7 @@
 import datetime
 
 from django.test import TestCase, Client
-from api.tests.common import signinAs, setupCC, createUsers, makeCommunity, makeUser, make_technology, createImage, \
+from api.tests.common import signinAs, createUsers, makeCommunity, makeUser, make_technology, createImage, \
     makeTestimonial, makeEvent
 from _main_.utils.utils import Console
 from apps__campaigns.models import Campaign, CampaignAccount, CampaignManager, CampaignCommunity, CampaignTechnology, CampaignTechnologyEvent, \
@@ -19,7 +19,7 @@ class CampaignsIntegrationTestCase(TestCase):
         self.client = Client()
         self.USER, self.CADMIN, self.SADMIN = createUsers()
         signinAs(self.client, self.SADMIN)
-        setupCC(self.client)
+        # setupCC(self.client)
         self.user = makeUser()
         self.IMAGE = createImage("https://www.whitehouse.gov/wp-content/uploads/2021/04/P20210303AS-1901-cropped.jpg")
         self.COMMUNITY_1 = makeCommunity()

--- a/src/api/tests/test_message.py
+++ b/src/api/tests/test_message.py
@@ -3,7 +3,7 @@ from database.models import Community, Message
 from django.test import TestCase, Client
 from unittest.mock import patch
 from api.tasks import send_scheduled_email
-from api.tests.common import signinAs, setupCC, createUsers
+from api.tests.common import signinAs, createUsers
 from urllib.parse import urlencode
 from _main_.utils.utils import Console
 

--- a/src/api/tests/test_technology.py
+++ b/src/api/tests/test_technology.py
@@ -2,7 +2,7 @@ import datetime
 import json
 
 from django.test import TestCase, Client
-from api.tests.common import signinAs, setupCC, createUsers, makeCommunity, makeUser, make_technology, createImage, \
+from api.tests.common import signinAs, createUsers, makeCommunity, makeUser, make_technology, createImage, \
     make_vendor
 from _main_.utils.utils import Console
 from apps__campaigns.models import Campaign, CampaignAccount, TechnologyVendor, TechnologyCoach, TechnologyOverview, TechnologyDeal
@@ -19,7 +19,7 @@ class TechnologiesIntegrationTestCase(TestCase):
         self.client = Client()
         self.USER, self.CADMIN, self.SADMIN = createUsers()
         signinAs(self.client, self.SADMIN)
-        setupCC(self.client)
+        # setupCC(self.client)
         self.user = makeUser()
         self.IMAGE = createImage("https://www.whitehouse.gov/wp-content/uploads/2021/04/P20210303AS-1901-cropped.jpg")
 


### PR DESCRIPTION
The setupCC method has been removed from the test_message, test_campaigns, and test_technology files. This change simplifies the setup process of each test by only utilizing the necessary methods from the common module, resulting in a cleaner and more efficient code.

####  Summary / Highlights

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
