### PR TITLE
fixing url import bug as we upgraded to Django-4.2.1

### DIFF
--- a/src/_main_/admin_urls.py
+++ b/src/_main_/admin_urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import path
 
 urlpatterns = [
-  url(r'',  admin.site.urls),
+  path(r'',  admin.site.urls),
 ]

--- a/src/_main_/urls.py
+++ b/src/_main_/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/cc/',include('carbon_calculator.urls')),
     path('cc/',include('carbon_calculator.urls')),
+    path('mc/',include('_main_.admin_urls')),
     path('auth/', include('authentication.urls')),
     path('authentication/', include('authentication.urls')),
     path('api/', include('api.urls')),

--- a/src/api/tests/test_endpoints.py
+++ b/src/api/tests/test_endpoints.py
@@ -1,0 +1,14 @@
+from django.test import TestCase, Client
+
+class EndpointTestCase(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_mc_endpoint(self):
+        response = self.client.get('/mc/login/')
+        self.assertEqual(response.status_code, 200)
+
+
+    def test_admin_endpoint(self):
+        response = self.client.get('/admin/login/')
+        self.assertEqual(response.status_code, 200)

--- a/src/carbon_calculator/urls.py
+++ b/src/carbon_calculator/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path
-#from .views import index, ping, actioninfo, eventinfo, groupinfo, stationinfo, eventsummary, userinfo, estimate, reset, importcsv, exportcsv, users, undo
 from .views import index, actioninfo, estimate, importcsv, exportcsv, reset
 
 urlpatterns = [

--- a/src/website/urls.py
+++ b/src/website/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import path
 from website import views
 
 urlpatterns = [


### PR DESCRIPTION
####  Summary / Highlights
When we migrated to Django 4.2.1, we got into an issue where one of our files was importing `url` from the wrong place. 

Updated it to use path instead.  See file changes.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
We were getting this error before:
```
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/api/src/_main_/admin_urls.py", line 1, in <module>
    from django.conf.urls import include, url
ImportError: cannot import name 'url' from 'django.conf.urls' (.../Library/Python/3.9/lib/python/site-packages/django/conf/urls/__init__.py)
[14/Jun/2024 10:40:28] "GET /favicon.ico HTTP/1.1" 500 59
```
#### Testing Steps (Provide details on how your changes can be tested)
Added unit tests to ensure that this does not happen again


#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
