### PR TITLE
fix: Fix for "CSRF verification failed. Request aborted." issue in Django Admin login on Dev and Canary.

### DIFF
--- a/src/_main_/settings.py
+++ b/src/_main_/settings.py
@@ -59,6 +59,8 @@ ALLOWED_HOSTS = [
 # get the domains we set in our vault and add them.
 ALLOWED_HOSTS.extend(EnvConfig.get_allowlist_domains())
 
+CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
+
 if RUN_SERVER_LOCALLY:
     ALLOWED_HOSTS = ['*']
     

--- a/src/_main_/settings.py
+++ b/src/_main_/settings.py
@@ -59,7 +59,7 @@ ALLOWED_HOSTS = [
 # get the domains we set in our vault and add them.
 ALLOWED_HOSTS.extend(EnvConfig.get_allowlist_domains())
 
-CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
+CSRF_TRUSTED_ORIGINS = EnvConfig.get_trusted_origins()
 
 if RUN_SERVER_LOCALLY:
     ALLOWED_HOSTS = ['*']

--- a/src/_main_/utils/stage/__init__.py
+++ b/src/_main_/utils/stage/__init__.py
@@ -180,4 +180,9 @@ class MassEnergizeApiEnvConfig:
     def get_release_info(self):
         release_info = load_json("release_info.json")
         return release_info
+    
+    def get_trusted_origins(self):
+        origins = os.getenv('CSRF_TRUSTED_ORIGINS', '').split(",")
+        origins = [o.strip() for o in origins if o.strip()]
+        return origins or []
         


### PR DESCRIPTION
####  Summary / Highlights
This Pull Request addresses the issue where login attempts into the Django Admin site from Dev and Canary environments were aborting due to a CSRF verification failure.

The problem was fixed by adding the CSRF_TRUSTED_ORIGINS setting in the main Django's setting file. The values for ALLOWED_HOSTS are used to set this new setting, ensuring all domains in ALLOWED_HOSTS are recognized as trusted origins for CSRF protection.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
