### PR TITLE
Fix for Event Nudge Location Display Issue

### DIFF
--- a/src/task_queue/helpers.py
+++ b/src/task_queue/helpers.py
@@ -50,3 +50,19 @@ def is_time_to_run(task):
 	else:
 		
 		return False
+
+
+def get_event_location(event):
+	evnt_type = event.get("event_type", "").lower()
+	location_mapping = {
+		"both": "Hybrid",
+		"in-person": "In-Person",
+		"online": "Online",
+	}
+	location = location_mapping.get(evnt_type, None)
+	if location:
+		return location
+	
+	if event.get("location"): return "In-Person"
+	if event.get("online_location"): return "Online"
+	return "N/A"

--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -159,23 +159,6 @@ def get_logo(event):
         return event.get("community").get("logo").get("url")
     return ""
 
-
-def get_event_location(event):
-    evnt_type = event.get("event_type", "").lower()
-    location_mapping = {
-        "both": "Hybrid",
-        "in-person": "In-Person",
-        "online": "Online",
-    }
-    location = location_mapping.get(evnt_type, None)
-    if location:
-        return location
-    
-    if event.get("location"): return "In-Person"
-    if event.get("online_location"): return "Online"
-    return "N/A"
-    
-
 def prepare_events_email_data(events):
     events = serialize_all(events, full=True)
     data = [{

--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -158,6 +158,23 @@ def get_logo(event):
         return event.get("community").get("logo").get("url")
     return ""
 
+
+def get_event_location(event):
+    evnt_type = event.get("event_type", "").lower()
+    location_mapping = {
+        "both": "Hybrid",
+        "in-person": "In-Person",
+        "online": "Online",
+    }
+    location = location_mapping.get(evnt_type, None)
+    if location:
+        return location
+    
+    if event.get("location"): return "In-Person"
+    if event.get("online_location"): return "Online"
+    return "N/A"
+    
+
 def prepare_events_email_data(events):
     events = serialize_all(events, full=True)
     data = [{
@@ -165,7 +182,7 @@ def prepare_events_email_data(events):
             "title": event.get("name"),
             "community": event.get("community", {}).get("name") if event.get("community") else "N/A",
             "date": human_readable_date(event.get("start_date_and_time")),
-            "location": "In person" if event.get("location") else "Online",
+            "location": get_event_location(event),
             "share_link": generate_redirect_url("SHARING", event.get("id")),
             "view_link": generate_redirect_url("VIEW", event.get("id"), event.get("community")),
             } for event in events]

--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -14,6 +14,7 @@ import pytz
 from django.db.models import Q
 from dateutil.relativedelta import relativedelta
 
+from task_queue.helpers import get_event_location
 
 WEEKLY = "weekly"
 BI_WEEKLY = "bi-weekly"

--- a/src/task_queue/nudges/user_event_nudge.py
+++ b/src/task_queue/nudges/user_event_nudge.py
@@ -17,6 +17,8 @@ from datetime import timedelta
 from database.utils.settings.model_constants.events import EventConstants
 from django.utils import timezone
 
+from task_queue.helpers import get_event_location
+
 WEEKLY = "per_week"
 BI_WEEKLY = "biweekly"
 MONTHLY = "per_month"
@@ -210,7 +212,7 @@ def prepare_events_email_data(events):
             "logo": get_logo(event),
             "title": truncate_title(event.get("name")),
             "date": get_date_range(event.get("start_date_and_time"), event.get("end_date_and_time")),
-            "location": "In person" if event.get("location") else "Online",
+            "location": get_event_location(event),
             "view_link": f'{COMMUNITY_URL_ROOT}/{event.get("community", {}).get("subdomain")}/events/{event.get("id")}',
             } for event in events]
     return data


### PR DESCRIPTION
####  Summary / Highlights
This pull request addresses an issue where the event nudge location was incorrectly displayed as 'Online' for hybrid events. The changes introduced in this PR ensure that the location is accurately displayed as 'Hybrid' when the event is both online and in-person. After merging this PR, the location display for hybrid events will be corrected.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
<img width="1063" alt="Screenshot 2024-06-24 at 1 34 09 PM" src="https://github.com/massenergize/api/assets/42780120/d2f02b3e-2c22-4f2d-abda-bfd8a4c4db63">

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
