### PR TITLE
Fix: Display Issue of Child Menu Items

### DIFF
--- a/src/api/utils/api_utils.py
+++ b/src/api/utils/api_utils.py
@@ -278,6 +278,8 @@ def remove_unpublished_items(content):
             if item.get("is_published"):
                 published_items.append(item)
         else:
+            if not item.get("is_published"):
+                continue
             item["children"] = remove_unpublished_items(item["children"])
             if item["children"]:
                 published_items.append(item)

--- a/src/database/raw_data/portal/menu.json
+++ b/src/database/raw_data/portal/menu.json
@@ -3,6 +3,7 @@
     {
       "name": "Home",
       "id": "menu-home-id",
+      "is_published": true,
       "children": [
         {
           "link": "/",
@@ -23,6 +24,7 @@
     {
       "name": "Actions",
       "id": "menu-actions-id",
+      "is_published": true,
       "children": [
         {
           "link": "/actions",
@@ -65,6 +67,7 @@
     {
       "name": "About Us",
       "id": "menu-about-us-id",
+      "is_published": true,
       "children": [
         {
           "link": "/impact",


### PR DESCRIPTION
####  Summary / Highlights
This Pull Request addresses a specific issue where child menu items were being displayed even when their parent menu item was disabled. The changes introduced in this PR ensure that child menu items adhere to the visibility status of their parent menu item. After merging this PR, child menu items will only be displayed if their parent menu item is enabled, enhancing the consistency and usability of our navigation menus.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
