### PR TITLE
Fix: Community admin feature flag list

### DIFF
--- a/src/api/services/community.py
+++ b/src/api/services/community.py
@@ -161,6 +161,6 @@ class CommunityService:
     feature_flags, err = self.store.list_communities_feature_flags(context, args)
     if err:
       return None, err
-    return serialize_all(feature_flags, info=True), None
+    return feature_flags, None
 
 

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -1397,7 +1397,15 @@ class CommunityStore:
                 (Q(audience=FeatureFlagConstants().for_all_except()) & ~Q(communities__in=communities))
             ).exclude(expires_on__lt=datetime.now()).prefetch_related('communities')
             
-            return feature_flags, None
+            ff = []
+            for flag in feature_flags:
+                ff.append({
+                    "key": flag.key,
+                    "name": flag.name,
+                    "communities": None if subdomain or community_id else [c.id for c in flag.enabled_communities() if c.id in communities]
+                })
+            
+            return ff, None
         
         except Exception as e:
             return None, CustomMassenergizeError(str(e))

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -3906,7 +3906,7 @@ class FeatureFlag(models.Model):
         elif self.audience == "ALL_EXCEPT":
             return communities_in.exclude(id__in=community_ids)
         
-        return None
+        return []
 
     def enabled_users(self, users_in: QuerySet):
         if self.user_audience == "EVERYONE":


### PR DESCRIPTION
####  Summary / Highlights
This pull request adds the communities a feature flag is enabled for when the signed-in user is a community admin with multiple communities.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
