### PR TITLE
 chore: Remove "Rewiring America" item from portal menu data

### DIFF
--- a/src/database/raw_data/portal/menu.json
+++ b/src/database/raw_data/portal/menu.json
@@ -13,13 +13,6 @@
           "is_published": true
         },
         {
-          "link": "/rewiring-america",
-          "name": "Rewiring America",
-          "id": "rewiring-america-id",
-          "is_link_external": false,
-          "is_published": true
-        },
-        {
           "link": "/?tour=true",
           "name": "Take the tour",
           "id": "menu-take-the-tour-id",


### PR DESCRIPTION
####  Summary / Highlights
The "Rewiring America" item has been removed from the application's portal menu JSON data. This is because a few things have to be fixed before we can include it to the list of menu items
#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ ] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
