### PR TITLE
Use Custom massenergize logger that logs to both CW and sentry.io

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -98,14 +98,14 @@ export TEST_OUTPUTS=$(outfile)
 export GENERATE_INPUTS=$(generate_inputs)
 
 test:
-	 if [[ -f "test.sqlite3" ]]; \
-	 then \
-	  rm test.sqlite3; \
-	 fi
-	 touch test.sqlite3
-	 DJANGO_ENV=test python3 manage.py migrate
-	 DJANGO_ENV=test coverage run --source='.' manage.py test $(package)
-	 coverage report --precision=2
+	if [[ -f "test.sqlite3" ]]; \
+	then \
+	rm test.sqlite3; \
+	fi
+	touch test.sqlite3
+	DJANGO_ENV=test python3 manage.py migrate
+	DJANGO_ENV=test python3 -m coverage run --source='.' manage.py test $(package)
+
 .PHONY: test
 
 celery:

--- a/src/_main_/utils/GeoIP.py
+++ b/src/_main_/utils/GeoIP.py
@@ -3,7 +3,7 @@ import geoip2.database
 import socket
 from user_agents import parse
 from _main_.settings import RUN_SERVER_LOCALLY
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 def ip_valid(ip):
 
@@ -23,7 +23,7 @@ class GeoIP:
     except Exception as e:
       # presumably file not found, in the case of running locally
       if not RUN_SERVER_LOCALLY:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
 
       self.reader = None  # open in first call to GetGeo to avoid crashing developers running locally: geoip2.database.Reader('_main_/utils/GeoLite2-City/GeoLite2-City.mmdb')
 

--- a/src/_main_/utils/GeoIP.py
+++ b/src/_main_/utils/GeoIP.py
@@ -3,7 +3,7 @@ import geoip2.database
 import socket
 from user_agents import parse
 from _main_.settings import RUN_SERVER_LOCALLY
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 def ip_valid(ip):
 
@@ -23,7 +23,7 @@ class GeoIP:
     except Exception as e:
       # presumably file not found, in the case of running locally
       if not RUN_SERVER_LOCALLY:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
 
       self.reader = None  # open in first call to GetGeo to avoid crashing developers running locally: geoip2.database.Reader('_main_/utils/GeoLite2-City/GeoLite2-City.mmdb')
 

--- a/src/_main_/utils/activity_logger/__init__.py
+++ b/src/_main_/utils/activity_logger/__init__.py
@@ -1,7 +1,7 @@
 import threading
 import time
 from database.models import ActivityLog
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 class ActivityLogger:
 
@@ -40,7 +40,7 @@ class ActivityLogger:
       )
       activity_log.save()
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
     
     
   def log(self, params):

--- a/src/_main_/utils/activity_logger/__init__.py
+++ b/src/_main_/utils/activity_logger/__init__.py
@@ -1,7 +1,7 @@
 import threading
 import time
 from database.models import ActivityLog
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 class ActivityLogger:
 
@@ -40,7 +40,7 @@ class ActivityLogger:
       )
       activity_log.save()
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
     
     
   def log(self, params):

--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -6,7 +6,7 @@ import pytz
 from django.utils import timezone
 from datetime import datetime, timedelta
 from dateutil import tz
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 import base64
 import pyshorteners
 from openpyxl import Workbook
@@ -48,7 +48,7 @@ def get_request_contents(request, **kwargs):
         return args
 
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return {}
 
 
@@ -67,14 +67,14 @@ def parse_list(d):
         return res
 
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return []
 
 def parse_dict(d: object) -> object:
     try:
         return json.loads(d)
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return dict()
 
 
@@ -85,7 +85,7 @@ def parse_str_list(d):
             return tmp
         return []
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return []
 
 
@@ -108,7 +108,7 @@ def parse_string(s):
             return None
         return s
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return None
 
 
@@ -116,7 +116,7 @@ def parse_string(s):
 #     try:
 #         return int(b)
 #     except Exception as e:
-#         logger.error(message=str(e), exception=e)
+#         log.exception(e)
 #         return 1
 
 def parse_int(b):
@@ -125,7 +125,7 @@ def parse_int(b):
     try:
         return int(b)
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return 1
 
 def parse_date(d):
@@ -138,7 +138,7 @@ def parse_date(d):
             return pytz.utc.localize(datetime.strptime(d, "%Y-%m-%d %H:%M"))
 
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return timezone.now()
 
 

--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -6,7 +6,7 @@ import pytz
 from django.utils import timezone
 from datetime import datetime, timedelta
 from dateutil import tz
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 import base64
 import pyshorteners
 from openpyxl import Workbook
@@ -48,7 +48,7 @@ def get_request_contents(request, **kwargs):
         return args
 
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return {}
 
 
@@ -67,14 +67,14 @@ def parse_list(d):
         return res
 
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return []
 
 def parse_dict(d: object) -> object:
     try:
         return json.loads(d)
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return dict()
 
 
@@ -85,7 +85,7 @@ def parse_str_list(d):
             return tmp
         return []
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return []
 
 
@@ -108,7 +108,7 @@ def parse_string(s):
             return None
         return s
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return None
 
 
@@ -116,7 +116,7 @@ def parse_string(s):
 #     try:
 #         return int(b)
 #     except Exception as e:
-#         capture_message(str(e), level="error")
+#         logger.error(message=str(e), exception=e)
 #         return 1
 
 def parse_int(b):
@@ -125,7 +125,7 @@ def parse_int(b):
     try:
         return int(b)
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return 1
 
 def parse_date(d):
@@ -138,7 +138,7 @@ def parse_date(d):
             return pytz.utc.localize(datetime.strptime(d, "%Y-%m-%d %H:%M"))
 
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return timezone.now()
 
 

--- a/src/_main_/utils/emailer/send_email.py
+++ b/src/_main_/utils/emailer/send_email.py
@@ -3,7 +3,7 @@ from django.core.mail import send_mail, EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 import requests
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 import pystmark
 
 from _main_.settings import IS_CANARY, POSTMARK_ACCOUNT_TOKEN, POSTMARK_EMAIL_SERVER_TOKEN, POSTMARK_DOWNLOAD_SERVER_TOKEN, IS_PROD
@@ -34,7 +34,7 @@ def send_massenergize_email(subject, msg, to, sender=None):
 
   if not response.ok:
     #if IS_PROD:
-    #  capture_message(f"Error Occurred in Sending Email to {to}", level="error")
+    #  logger.error(f"Error Occurred in Sending Email to {to}", level="error")
     return False
   return True
 
@@ -56,7 +56,7 @@ def send_massenergize_email_with_attachments(temp, t_model, to, file, file_name,
   if not response.ok:
     logging.error("EMAILING_ERROR: "+str(response.json()))
     #if IS_PROD:
-    #  capture_message(f"Error Occurred in Sending Email to {to}", level="error")
+    #  logger.error(f"Error Occurred in Sending Email to {to}", level="error")
     return False
   return True
   
@@ -81,7 +81,7 @@ def send_massenergize_rich_email(subject, to, massenergize_email_type, content_v
 
   if not response.ok:
     #if IS_PROD:
-    #  capture_message(f"Error Occurred in Sending Email to {to}", level="error")
+    #  logger.error(f"Error Occurred in Sending Email to {to}", level="error")
     return False
   return True
 
@@ -99,7 +99,7 @@ def send_massenergize_mass_email(subject, msg, recipient_emails):
 
   if not response.ok:
     #if IS_PROD:
-    #  capture_message("Error occurred in sending some emails", level="error")
+    #  logger.error("Error occurred in sending some emails", level="error")
     return False
 
   return True

--- a/src/_main_/utils/emailer/send_email.py
+++ b/src/_main_/utils/emailer/send_email.py
@@ -3,7 +3,7 @@ from django.core.mail import send_mail, EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 import requests
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 import pystmark
 
 from _main_.settings import IS_CANARY, POSTMARK_ACCOUNT_TOKEN, POSTMARK_EMAIL_SERVER_TOKEN, POSTMARK_DOWNLOAD_SERVER_TOKEN, IS_PROD
@@ -34,7 +34,7 @@ def send_massenergize_email(subject, msg, to, sender=None):
 
   if not response.ok:
     #if IS_PROD:
-    #  logger.error(f"Error Occurred in Sending Email to {to}", level="error")
+    #  log.error(f"Error Occurred in Sending Email to {to}", level="error")
     return False
   return True
 
@@ -56,7 +56,7 @@ def send_massenergize_email_with_attachments(temp, t_model, to, file, file_name,
   if not response.ok:
     logging.error("EMAILING_ERROR: "+str(response.json()))
     #if IS_PROD:
-    #  logger.error(f"Error Occurred in Sending Email to {to}", level="error")
+    #  log.error(f"Error Occurred in Sending Email to {to}", level="error")
     return False
   return True
   
@@ -81,7 +81,7 @@ def send_massenergize_rich_email(subject, to, massenergize_email_type, content_v
 
   if not response.ok:
     #if IS_PROD:
-    #  logger.error(f"Error Occurred in Sending Email to {to}", level="error")
+    #  log.error(f"Error Occurred in Sending Email to {to}", level="error")
     return False
   return True
 
@@ -99,7 +99,7 @@ def send_massenergize_mass_email(subject, msg, recipient_emails):
 
   if not response.ok:
     #if IS_PROD:
-    #  logger.error("Error occurred in sending some emails", level="error")
+    #  log.error("Error occurred in sending some emails", level="error")
     return False
 
   return True

--- a/src/_main_/utils/massenergize_logger/__init__.py
+++ b/src/_main_/utils/massenergize_logger/__init__.py
@@ -1,0 +1,47 @@
+"""
+This utility lets us flush our logs to both sentry and cloudwatch.
+"""
+import logging
+import sentry_sdk
+from _main_.settings import EnvConfig
+from _main_.utils.utils import run_in_background
+
+class MassenergizeLogger:
+    def __init__(self):
+        self.logger = logging.getLogger(EnvConfig.get_logger_identifier())
+
+
+    @run_in_background
+    def _log(self, level, message, exception=None, extra={}):
+
+        if exception:
+            extra['exception'] = exception
+
+        # log through the python django logger which goes to Cloudwatch
+        if level >= logging.ERROR:
+            self.logger.log(
+                level,
+                message, 
+                exc_info=True,
+                stack_info=True, 
+                stacklevel=2,
+                extra=extra
+            )
+
+            logger.error(exception, scope_args=extra)
+
+        else:
+            self.logger.log(level, message, extra=extra)
+
+            # send log to sentry
+            sentry_sdk.capture_message(message, level, scope_args=extra)
+            
+
+    def info(self, message, extra={}):
+        self._log(logging.INFO, message, extra=extra)
+
+    def error(self, message=None, exception=None, extra={}):
+        self._log(logging.ERROR, message or str(exception), exception, extra)
+
+
+logger = MassenergizeLogger()

--- a/src/_main_/utils/massenergize_logger/__init__.py
+++ b/src/_main_/utils/massenergize_logger/__init__.py
@@ -58,6 +58,7 @@ class MassenergizeLogger:
 
     def exception(self, exception):
         self.error(str(exception), exception)
+        return exception
 
 
 log = MassenergizeLogger()

--- a/src/_main_/utils/massenergize_logger/__init__.py
+++ b/src/_main_/utils/massenergize_logger/__init__.py
@@ -56,5 +56,8 @@ class MassenergizeLogger:
     def error(self, message=None, exception=None, extra={}):
         self._log(logging.ERROR, message or str(exception), exception, extra)
 
+    def exception(self, exception):
+        self.error(str(exception), exception)
 
-logger = MassenergizeLogger()
+
+log = MassenergizeLogger()

--- a/src/_main_/utils/metrics/__init__.py
+++ b/src/_main_/utils/metrics/__init__.py
@@ -4,6 +4,7 @@ import boto3
 import threading
 import random 
 from _main_.settings import EnvConfig
+from _main_.utils.massenergize_logger import logger
 
 DEFAULT_CAPTURE_RATE = .7 # for now we want to capture 50% of the logs.
 FUNCTION_LATENCY_NAMESPACE = "ApiService/FunctionPerformance"
@@ -67,7 +68,7 @@ def put_metric_data(name_space, metric_data):
         )
         print(f"Metric {metric_data[0]['MetricName']} sent to CloudWatch: {metric_data[0]['Value']} ms\n")
     except Exception as e:
-        print(e)
+        logger.error(message=str(e), exception=e)
 
 def timed_with_dimensions(dimensions=None, capture_rate=DEFAULT_CAPTURE_RATE):
     

--- a/src/_main_/utils/metrics/__init__.py
+++ b/src/_main_/utils/metrics/__init__.py
@@ -4,7 +4,7 @@ import boto3
 import threading
 import random 
 from _main_.settings import EnvConfig
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 DEFAULT_CAPTURE_RATE = .7 # for now we want to capture 50% of the logs.
 FUNCTION_LATENCY_NAMESPACE = "ApiService/FunctionPerformance"
@@ -68,7 +68,7 @@ def put_metric_data(name_space, metric_data):
         )
         print(f"Metric {metric_data[0]['MetricName']} sent to CloudWatch: {metric_data[0]['Value']} ms\n")
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
 
 def timed_with_dimensions(dimensions=None, capture_rate=DEFAULT_CAPTURE_RATE):
     

--- a/src/_main_/utils/metrics/middleware.py
+++ b/src/_main_/utils/metrics/middleware.py
@@ -1,13 +1,8 @@
 import time
 import boto3
-import logging
+from _main_.utils.massenergize_logger import logger
 from django.utils.deprecation import MiddlewareMixin
-from botocore.exceptions import NoCredentialsError, ClientError
-from _main_.settings import EnvConfig
-
-
 from _main_.utils.utils import run_in_background
-logger = logging.getLogger(EnvConfig.get_logger_identifier())
 
 class MetricsMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
@@ -26,5 +21,9 @@ class MetricsMiddleware(MiddlewareMixin):
         if not hasattr(request, 'start_time'):
             return
         latency = (time.time() - request.start_time) * 1000 # convert to milliseconds
-        logger.info(f"Path: {request.path} Latency(ms): {latency}")
+        
+        logger.info(
+            f"Path: {request.path} Latency(ms): {latency}", 
+            extra={"path": request.path, "latency": latency}
+        )
 

--- a/src/_main_/utils/metrics/middleware.py
+++ b/src/_main_/utils/metrics/middleware.py
@@ -1,6 +1,6 @@
 import time
 import boto3
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from django.utils.deprecation import MiddlewareMixin
 from _main_.utils.utils import run_in_background
 
@@ -22,7 +22,7 @@ class MetricsMiddleware(MiddlewareMixin):
             return
         latency = (time.time() - request.start_time) * 1000 # convert to milliseconds
         
-        logger.info(
+        log.info(
             f"Path: {request.path} Latency(ms): {latency}", 
             extra={"path": request.path, "latency": latency}
         )

--- a/src/_main_/utils/validator/__init__.py
+++ b/src/_main_/utils/validator/__init__.py
@@ -1,6 +1,6 @@
 from _main_.utils.massenergize_errors import CustomMassenergizeError
 from _main_.utils.common import parse_bool, parse_date, parse_list, parse_int, parse_string, parse_location, is_value, parse_str_list, parse_dict
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 
 class Validator:
@@ -119,5 +119,5 @@ class Validator:
       self.fields = {}
       self.rename_fields = set()
 
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/_main_/utils/validator/__init__.py
+++ b/src/_main_/utils/validator/__init__.py
@@ -1,6 +1,6 @@
 from _main_.utils.massenergize_errors import CustomMassenergizeError
 from _main_.utils.common import parse_bool, parse_date, parse_list, parse_int, parse_string, parse_location, is_value, parse_str_list, parse_dict
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 
 class Validator:
@@ -119,5 +119,5 @@ class Validator:
       self.fields = {}
       self.rename_fields = set()
 
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/decorators.py
+++ b/src/api/decorators.py
@@ -6,8 +6,8 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from _main_.utils.context import Context
 from functools import wraps
-from django.views.decorators.http import require_http_methods
-
+from _main_.utils.massenergize_errors import NotAuthorizedError
+from _main_.utils.massenergize_logger import log
 
 def x_frame_options_exempt(view_func):
     @wraps(view_func)
@@ -17,6 +17,8 @@ def x_frame_options_exempt(view_func):
             response['X-Frame-Options'] = 'ALLOWALL'
         return response
     return wrapped_view
+
+
 def login_required(function):
   """
   This decorator enforces that a user is logged in before a view can run
@@ -27,7 +29,8 @@ def login_required(function):
     if context.user_is_logged_in:
       return function(handler, request, *args, **kwargs)
     else:
-      raise PermissionDenied
+      log.exception(PermissionDenied)
+      return NotAuthorizedError()
 
   wrap.__doc__ = function.__doc__
   wrap.__name__ = function.__name__
@@ -44,7 +47,9 @@ def admins_only(function):
     if context.user_is_logged_in and context.user_is_admin():
       return function(handler, request, *args, **kwargs)
     else:
-      raise PermissionDenied
+      log.exception(PermissionDenied)
+      return NotAuthorizedError()
+
   wrap.__doc__ = function.__doc__
   wrap.__name__ = function.__name__
   return wrap
@@ -59,7 +64,8 @@ def community_admins_only(function):
     if context.user_is_logged_in and context.user_is_community_admin:
       return function(handler, request, *args, **kwargs)
     else:
-      raise PermissionDenied
+      log.exception(PermissionDenied)
+      return NotAuthorizedError()
   wrap.__doc__ = function.__doc__
   wrap.__name__ = function.__name__
   return wrap
@@ -74,7 +80,8 @@ def super_admins_only(function):
     if context.user_is_logged_in and context.user_is_super_admin:
       return function(handler, request, *args, **kwargs)
     else:
-      raise PermissionDenied
+      log.exception(PermissionDenied)
+      return NotAuthorizedError()
 
   wrap.__doc__ = function.__doc__
   wrap.__name__ = function.__name__

--- a/src/api/handlers/page_settings__home.py
+++ b/src/api/handlers/page_settings__home.py
@@ -7,7 +7,7 @@ from api.services.page_settings__home import HomePageSettingsService
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
 from _main_.utils.validator import Validator
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from api.decorators import admins_only, super_admins_only, login_required
 
 class HomePageSettingsHandler(RouteHandler):

--- a/src/api/handlers/page_settings__home.py
+++ b/src/api/handlers/page_settings__home.py
@@ -7,7 +7,7 @@ from api.services.page_settings__home import HomePageSettingsService
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
 from _main_.utils.validator import Validator
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from api.decorators import admins_only, super_admins_only, login_required
 
 class HomePageSettingsHandler(RouteHandler):

--- a/src/api/services/action.py
+++ b/src/api/services/action.py
@@ -9,7 +9,7 @@ from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.utils import get_user_or_die
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class ActionService:
@@ -88,7 +88,7 @@ class ActionService:
       return serialize(action), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def update_action(self, context: Context, args, user_submitted=False) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/action.py
+++ b/src/api/services/action.py
@@ -9,7 +9,7 @@ from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.utils import get_user_or_die
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class ActionService:
@@ -88,7 +88,7 @@ class ActionService:
       return serialize(action), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def update_action(self, context: Context, args, user_submitted=False) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/admin.py
+++ b/src/api/services/admin.py
@@ -7,7 +7,7 @@ from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, IS_PROD, IS_CANARY
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class AdminService:
@@ -36,7 +36,7 @@ class AdminService:
             subject, admin.email, 'new_admin_email.html', content_variables, None)
         return serialize(admin, full=True), None
       except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return None, CustomMassenergizeError(e)
 
     def remove_super_admin(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -73,7 +73,7 @@ class AdminService:
         res["user"] = serialize(res.get("user"))
         return res, None
       except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return None, CustomMassenergizeError(e)
 
     def remove_community_admin(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -132,7 +132,7 @@ class AdminService:
 
         return serialize(message), None
       except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return None, CustomMassenergizeError(e)
    
     def list_admin_messages(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/admin.py
+++ b/src/api/services/admin.py
@@ -7,7 +7,7 @@ from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, IS_PROD, IS_CANARY
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class AdminService:
@@ -36,7 +36,7 @@ class AdminService:
             subject, admin.email, 'new_admin_email.html', content_variables, None)
         return serialize(admin, full=True), None
       except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return None, CustomMassenergizeError(e)
 
     def remove_super_admin(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -73,7 +73,7 @@ class AdminService:
         res["user"] = serialize(res.get("user"))
         return res, None
       except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return None, CustomMassenergizeError(e)
 
     def remove_community_admin(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -132,7 +132,7 @@ class AdminService:
 
         return serialize(message), None
       except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return None, CustomMassenergizeError(e)
    
     def list_admin_messages(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/auth.py
+++ b/src/api/services/auth.py
@@ -10,7 +10,7 @@ from _main_.utils.massenergize_errors import CustomMassenergizeError
 from database.models import Community, UserProfile
 from _main_.settings import SECRET_KEY
 import jwt
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 import requests
 import os
 from _main_.utils.metrics import timed
@@ -81,11 +81,11 @@ class AuthService:
       else:
         return None, None, CustomMassenergizeError("invalid_auth")
     except PermissionError:
-      capture_message("not_an_admin", level="error")
+      logger.error("not_an_admin", level="error")
       return None, None, CustomMassenergizeError('not_an_admin')
     except Exception as e:
       print(e)
-      capture_message("Authentication Error", level="error")
+      logger.error("Authentication Error", level="error")
       return None, None, CustomMassenergizeError(e)
 
 
@@ -107,7 +107,7 @@ class AuthService:
       return serialize(user, full=True), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
 
       return None, CustomMassenergizeError(e)
 
@@ -131,7 +131,7 @@ class AuthService:
           'Invalid reCAPTCHA. Please try again.')
           
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def guest_login(self, context: Context):
@@ -170,10 +170,10 @@ class AuthService:
       else:
         return None, None, CustomMassenergizeError("invalid_auth")
     #except PermissionError:
-    #  capture_message("not_an_admin", level="error")
+    #  logger.error("not_an_admin", level="error")
     #  return None, None, CustomMassenergizeError('not_an_admin')
     except Exception as e:
-      capture_message("Authentication Error", level="error")
+      logger.error("Authentication Error", level="error")
       return None, None, CustomMassenergizeError(e)
 
 
@@ -213,7 +213,7 @@ class AuthService:
       
 
     except Exception as e:
-      capture_message("Authentication Error", level="error")
+      logger.error("Authentication Error", level="error")
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/auth.py
+++ b/src/api/services/auth.py
@@ -10,7 +10,7 @@ from _main_.utils.massenergize_errors import CustomMassenergizeError
 from database.models import Community, UserProfile
 from _main_.settings import SECRET_KEY
 import jwt
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 import requests
 import os
 from _main_.utils.metrics import timed
@@ -81,11 +81,11 @@ class AuthService:
       else:
         return None, None, CustomMassenergizeError("invalid_auth")
     except PermissionError:
-      logger.error("not_an_admin", level="error")
+      log.error("not_an_admin", level="error")
       return None, None, CustomMassenergizeError('not_an_admin')
     except Exception as e:
       print(e)
-      logger.error("Authentication Error", level="error")
+      log.error("Authentication Error", level="error")
       return None, None, CustomMassenergizeError(e)
 
 
@@ -107,7 +107,7 @@ class AuthService:
       return serialize(user, full=True), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
 
       return None, CustomMassenergizeError(e)
 
@@ -131,7 +131,7 @@ class AuthService:
           'Invalid reCAPTCHA. Please try again.')
           
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def guest_login(self, context: Context):
@@ -170,10 +170,10 @@ class AuthService:
       else:
         return None, None, CustomMassenergizeError("invalid_auth")
     #except PermissionError:
-    #  logger.error("not_an_admin", level="error")
+    #  log.error("not_an_admin", level="error")
     #  return None, None, CustomMassenergizeError('not_an_admin')
     except Exception as e:
-      logger.error("Authentication Error", level="error")
+      log.error("Authentication Error", level="error")
       return None, None, CustomMassenergizeError(e)
 
 
@@ -213,7 +213,7 @@ class AuthService:
       
 
     except Exception as e:
-      logger.error("Authentication Error", level="error")
+      log.error("Authentication Error", level="error")
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/campaign.py
+++ b/src/api/services/campaign.py
@@ -4,7 +4,7 @@ from _main_.utils.pagination import paginate
 from _main_.utils.context import Context
 from api.store.campaign import CampaignStore
 from api.utils.filter_functions import sort_items
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 from apps__campaigns.helpers import generate_analytics_data, get_campaign_details, get_campaign_technology_details
@@ -61,7 +61,7 @@ class CampaignService:
             return serialize(campaign), None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_from_template(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -75,7 +75,7 @@ class CampaignService:
 
             return result, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/campaign.py
+++ b/src/api/services/campaign.py
@@ -4,7 +4,7 @@ from _main_.utils.pagination import paginate
 from _main_.utils.context import Context
 from api.store.campaign import CampaignStore
 from api.utils.filter_functions import sort_items
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 from apps__campaigns.helpers import generate_analytics_data, get_campaign_details, get_campaign_technology_details
@@ -61,7 +61,7 @@ class CampaignService:
             return serialize(campaign), None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_from_template(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -75,7 +75,7 @@ class CampaignService:
 
             return result, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/community.py
+++ b/src/api/services/community.py
@@ -1,4 +1,4 @@
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergizeAPIError
 from _main_.utils.pagination import paginate
 from api.store.community import CommunityStore
@@ -88,7 +88,7 @@ class CommunityService:
         obj[_id] = found
       return obj, None
     except Exception as e: 
-      e = logger.error(e)
+      e = log.error(e)
       return None,CustomMassenergizeError(e)
     # sorted = sort_items(communities, context.get_params())
     # return paginate(sorted, context.get_pagination_data()), None

--- a/src/api/services/community.py
+++ b/src/api/services/community.py
@@ -88,7 +88,7 @@ class CommunityService:
         obj[_id] = found
       return obj, None
     except Exception as e: 
-      e = log.error(e)
+      log.error(e)
       return None,CustomMassenergizeError(e)
     # sorted = sort_items(communities, context.get_params())
     # return paginate(sorted, context.get_pagination_data()), None

--- a/src/api/services/community.py
+++ b/src/api/services/community.py
@@ -1,4 +1,4 @@
-from sentry_sdk import capture_exception
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergizeAPIError
 from _main_.utils.pagination import paginate
 from api.store.community import CommunityStore
@@ -88,7 +88,7 @@ class CommunityService:
         obj[_id] = found
       return obj, None
     except Exception as e: 
-      e = capture_exception(e)
+      e = logger.error(e)
       return None,CustomMassenergizeError(e)
     # sorted = sort_items(communities, context.get_params())
     # return paginate(sorted, context.get_pagination_data()), None

--- a/src/api/services/deviceprofile.py
+++ b/src/api/services/deviceprofile.py
@@ -2,7 +2,7 @@ from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergi
 from _main_.utils.common import serialize, serialize_all
 from api.store.deviceprofile import DeviceStore
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class DeviceService:

--- a/src/api/services/deviceprofile.py
+++ b/src/api/services/deviceprofile.py
@@ -2,7 +2,7 @@ from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergi
 from _main_.utils.common import serialize, serialize_all
 from api.store.deviceprofile import DeviceStore
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class DeviceService:

--- a/src/api/services/event.py
+++ b/src/api/services/event.py
@@ -11,7 +11,7 @@ from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.utils import get_user_or_die
 from typing import Tuple
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from django.utils.safestring import mark_safe
 from database.models import HomePageSettings
 #import datetime
@@ -116,7 +116,7 @@ class EventService:
 
       return serialize(event_attendee), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def rsvp_remove(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -211,7 +211,7 @@ class EventService:
 
       return serialize(event), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/event.py
+++ b/src/api/services/event.py
@@ -11,7 +11,7 @@ from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.utils import get_user_or_die
 from typing import Tuple
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from django.utils.safestring import mark_safe
 from database.models import HomePageSettings
 #import datetime
@@ -116,7 +116,7 @@ class EventService:
 
       return serialize(event_attendee), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def rsvp_remove(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -211,7 +211,7 @@ class EventService:
 
       return serialize(event), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/message.py
+++ b/src/api/services/message.py
@@ -5,7 +5,7 @@ from api.store.message import MessageStore
 from api.store.team import TeamStore
 from _main_.utils.context import Context
 from _main_.utils.emailer.send_email import send_massenergize_email
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from api.utils.api_utils import get_sender_email
 
@@ -69,7 +69,7 @@ class MessageService:
       # return reply message
       return serialize(reply), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def forward_to_team_admins(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -116,7 +116,7 @@ class MessageService:
 
       return serialize(message), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def delete_message(self, message_id,context) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/message.py
+++ b/src/api/services/message.py
@@ -5,7 +5,7 @@ from api.store.message import MessageStore
 from api.store.team import TeamStore
 from _main_.utils.context import Context
 from _main_.utils.emailer.send_email import send_massenergize_email
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from api.utils.api_utils import get_sender_email
 
@@ -69,7 +69,7 @@ class MessageService:
       # return reply message
       return serialize(reply), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def forward_to_team_admins(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -116,7 +116,7 @@ class MessageService:
 
       return serialize(message), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def delete_message(self, message_id,context) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/subscriber.py
+++ b/src/api/services/subscriber.py
@@ -4,7 +4,7 @@ from _main_.utils.pagination import paginate
 from api.store.subscriber import SubscriberStore
 from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.utils.constants import COMMUNITY_URL_ROOT, ME_LOGO_PNG
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from api.utils.api_utils import get_sender_email
 
@@ -51,7 +51,7 @@ class SubscriberService:
 
       return serialize(subscriber), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def update_subscriber(self, subscriber_id, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/subscriber.py
+++ b/src/api/services/subscriber.py
@@ -4,7 +4,7 @@ from _main_.utils.pagination import paginate
 from api.store.subscriber import SubscriberStore
 from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.utils.constants import COMMUNITY_URL_ROOT, ME_LOGO_PNG
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from api.utils.api_utils import get_sender_email
 
@@ -51,7 +51,7 @@ class SubscriberService:
 
       return serialize(subscriber), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def update_subscriber(self, subscriber_id, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/team.py
+++ b/src/api/services/team.py
@@ -11,7 +11,7 @@ from _main_.utils.constants import ADMIN_URL_ROOT
 from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, IS_PROD, IS_CANARY
 from .utils import send_slack_message
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class TeamService:
@@ -160,7 +160,7 @@ class TeamService:
       return serialize(message), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/team.py
+++ b/src/api/services/team.py
@@ -11,7 +11,7 @@ from _main_.utils.constants import ADMIN_URL_ROOT
 from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, IS_PROD, IS_CANARY
 from .utils import send_slack_message
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class TeamService:
@@ -160,7 +160,7 @@ class TeamService:
       return serialize(message), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/testimonial.py
+++ b/src/api/services/testimonial.py
@@ -8,7 +8,7 @@ from api.utils.api_utils import get_sender_email
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.testimonial import TestimonialStore
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class TestimonialService:
@@ -84,7 +84,7 @@ class TestimonialService:
 
       return serialize(testimonial), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/testimonial.py
+++ b/src/api/services/testimonial.py
@@ -8,7 +8,7 @@ from api.utils.api_utils import get_sender_email
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.testimonial import TestimonialStore
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class TestimonialService:
@@ -84,7 +84,7 @@ class TestimonialService:
 
       return serialize(testimonial), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/services/userprofile.py
+++ b/src/api/services/userprofile.py
@@ -8,7 +8,7 @@ from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.utils.constants import COMMUNITY_URL_ROOT,  ME_LOGO_PNG
 import os, csv
 import re
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from api.utils.api_utils import get_sender_email
 
@@ -241,7 +241,7 @@ class UserService:
       user = serialize(user, full=True)
       return {**user, "is_new":True }, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -338,7 +338,7 @@ class UserService:
         return None, err
       return {'invalidEmails': invalid_emails}, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def import_from_list(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -381,7 +381,7 @@ class UserService:
           return None, CustomMassenergizeError(e)
       return {'invalidEmails': invalid_emails}, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
     
 

--- a/src/api/services/userprofile.py
+++ b/src/api/services/userprofile.py
@@ -8,7 +8,7 @@ from _main_.utils.emailer.send_email import send_massenergize_rich_email
 from _main_.utils.constants import COMMUNITY_URL_ROOT,  ME_LOGO_PNG
 import os, csv
 import re
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from api.utils.api_utils import get_sender_email
 
@@ -241,7 +241,7 @@ class UserService:
       user = serialize(user, full=True)
       return {**user, "is_new":True }, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -338,7 +338,7 @@ class UserService:
         return None, err
       return {'invalidEmails': invalid_emails}, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def import_from_list(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -381,7 +381,7 @@ class UserService:
           return None, CustomMassenergizeError(e)
       return {'invalidEmails': invalid_emails}, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
     
 

--- a/src/api/services/vendor.py
+++ b/src/api/services/vendor.py
@@ -10,7 +10,7 @@ from api.utils.api_utils import get_sender_email
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.utils import get_user_or_die, get_community_or_die
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class VendorService:
@@ -94,7 +94,7 @@ class VendorService:
       return serialize(vendor), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def update_vendor(self, context, args, user_submitted=False) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/vendor.py
+++ b/src/api/services/vendor.py
@@ -10,7 +10,7 @@ from api.utils.api_utils import get_sender_email
 from api.utils.filter_functions import sort_items
 from .utils import send_slack_message
 from api.store.utils import get_user_or_die, get_community_or_die
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class VendorService:
@@ -94,7 +94,7 @@ class VendorService:
       return serialize(vendor), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def update_vendor(self, context, args, user_submitted=False) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/services/webhook.py
+++ b/src/api/services/webhook.py
@@ -1,7 +1,7 @@
 
 import logging
 
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.massenergize_errors import MassEnergizeAPIError
 from _main_.utils.context import Context
 from typing import Tuple
@@ -166,7 +166,7 @@ class WebhookService:
         return {"success": True}, None
         
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         logging.error(f"INBOUND_PROCESSING_EXCEPTION: {str(e)}")
         return None, MassEnergizeAPIError(e)
 

--- a/src/api/services/webhook.py
+++ b/src/api/services/webhook.py
@@ -1,7 +1,7 @@
 
 import logging
 
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.massenergize_errors import MassEnergizeAPIError
 from _main_.utils.context import Context
 from typing import Tuple
@@ -166,7 +166,7 @@ class WebhookService:
         return {"success": True}, None
         
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         logging.error(f"INBOUND_PROCESSING_EXCEPTION: {str(e)}")
         return None, MassEnergizeAPIError(e)
 

--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -12,7 +12,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.context import Context
 from .utils import get_new_title
 from django.db.models import Q
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class ActionStore:
@@ -29,7 +29,7 @@ class ActionStore:
         return None, InvalidResourceError()
       return action, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   @timed
@@ -58,7 +58,7 @@ class ActionStore:
 
       return actions, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def add_tags(self, action, ccAction, tags = None):
@@ -159,7 +159,7 @@ class ActionStore:
       return new_action, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def copy_action(self, context: Context, args) -> Tuple[Action, MassEnergizeAPIError]:
@@ -219,7 +219,7 @@ class ActionStore:
       # ----------------------------------------------------------------
       return new_action, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
     
       return None, CustomMassenergizeError(e)
 
@@ -341,7 +341,7 @@ class ActionStore:
       # ----------------------------------------------------------------
       return action, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -363,7 +363,7 @@ class ActionStore:
       else:
         raise Exception("Action ID not provided to actions.rank")
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def delete_action(self, context: Context, args) -> Tuple[Action, MassEnergizeAPIError]:
@@ -387,7 +387,7 @@ class ActionStore:
       # ----------------------------------------------------------------
       return action_to_delete, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_actions_for_community_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -427,7 +427,7 @@ class ActionStore:
       return actions.distinct(), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -442,7 +442,7 @@ class ActionStore:
       actions = Action.objects.filter(*filter_params,is_deleted=False).select_related('image', 'community', 'calculator_action').prefetch_related('tags')
       return actions.distinct(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/store/action.py
+++ b/src/api/store/action.py
@@ -12,7 +12,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.context import Context
 from .utils import get_new_title
 from django.db.models import Q
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class ActionStore:
@@ -29,7 +29,7 @@ class ActionStore:
         return None, InvalidResourceError()
       return action, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   @timed
@@ -58,7 +58,7 @@ class ActionStore:
 
       return actions, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def add_tags(self, action, ccAction, tags = None):
@@ -159,7 +159,7 @@ class ActionStore:
       return new_action, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def copy_action(self, context: Context, args) -> Tuple[Action, MassEnergizeAPIError]:
@@ -219,7 +219,7 @@ class ActionStore:
       # ----------------------------------------------------------------
       return new_action, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
     
       return None, CustomMassenergizeError(e)
 
@@ -341,7 +341,7 @@ class ActionStore:
       # ----------------------------------------------------------------
       return action, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -363,7 +363,7 @@ class ActionStore:
       else:
         raise Exception("Action ID not provided to actions.rank")
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def delete_action(self, context: Context, args) -> Tuple[Action, MassEnergizeAPIError]:
@@ -387,7 +387,7 @@ class ActionStore:
       # ----------------------------------------------------------------
       return action_to_delete, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_actions_for_community_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -427,7 +427,7 @@ class ActionStore:
       return actions.distinct(), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -442,7 +442,7 @@ class ActionStore:
       actions = Action.objects.filter(*filter_params,is_deleted=False).select_related('image', 'community', 'calculator_action').prefetch_related('tags')
       return actions.distinct(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 

--- a/src/api/store/admin.py
+++ b/src/api/store/admin.py
@@ -6,7 +6,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, CustomMassene
 from _main_.utils.context import Context
 from .utils import get_community, get_user, get_community_or_die, unique_media_filename
 from api.store.community import CommunityStore
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class AdminStore:
@@ -37,7 +37,7 @@ class AdminStore:
       return user, None
       
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -64,7 +64,7 @@ class AdminStore:
       return user, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -76,7 +76,7 @@ class AdminStore:
       admins = UserProfile.objects.filter(is_super_admin=True, is_deleted=False, *filter_params)
       return admins, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -130,7 +130,7 @@ class AdminStore:
       return res, None
       
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -185,7 +185,7 @@ class AdminStore:
       return admin_group, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -208,7 +208,7 @@ class AdminStore:
 
       return community_admin_group, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -244,7 +244,7 @@ class AdminStore:
       return new_message, None 
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_admin_messages(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -275,5 +275,5 @@ class AdminStore:
       messages = Message.objects.filter(community__id = community.id, is_deleted=False).select_related('uploaded_file', 'community', 'user')
       return messages, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/admin.py
+++ b/src/api/store/admin.py
@@ -6,7 +6,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, CustomMassene
 from _main_.utils.context import Context
 from .utils import get_community, get_user, get_community_or_die, unique_media_filename
 from api.store.community import CommunityStore
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class AdminStore:
@@ -37,7 +37,7 @@ class AdminStore:
       return user, None
       
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -64,7 +64,7 @@ class AdminStore:
       return user, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -76,7 +76,7 @@ class AdminStore:
       admins = UserProfile.objects.filter(is_super_admin=True, is_deleted=False, *filter_params)
       return admins, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -130,7 +130,7 @@ class AdminStore:
       return res, None
       
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -185,7 +185,7 @@ class AdminStore:
       return admin_group, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -208,7 +208,7 @@ class AdminStore:
 
       return community_admin_group, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -244,7 +244,7 @@ class AdminStore:
       return new_message, None 
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_admin_messages(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -275,5 +275,5 @@ class AdminStore:
       messages = Message.objects.filter(community__id = community.id, is_deleted=False).select_related('uploaded_file', 'community', 'user')
       return messages, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/campaign.py
+++ b/src/api/store/campaign.py
@@ -39,7 +39,7 @@ from _main_.utils.massenergize_errors import (
 from _main_.utils.context import Context
 from .utils import get_user_from_context
 from django.db.models import Q
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from django.db import transaction
 
@@ -69,7 +69,7 @@ class CampaignStore:
             return campaign, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaigns(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -87,7 +87,7 @@ class CampaignStore:
 
             return campaigns.distinct().order_by("-created_at"), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign(
@@ -156,7 +156,7 @@ class CampaignStore:
             return new_campaign, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaigns(
@@ -197,7 +197,7 @@ class CampaignStore:
 
             return campaigns.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_campaign(
@@ -222,7 +222,7 @@ class CampaignStore:
 
             return campaign_to_delete, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaigns_for_admins(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -248,7 +248,7 @@ class CampaignStore:
             return campaigns.distinct().order_by("-created_at"), None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaigns_for_super_admin(self, context: Context):
@@ -256,7 +256,7 @@ class CampaignStore:
             campaigns = Campaign.objects.filter(is_deleted=False)
             return campaigns.order_by("-created_at"), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_manager(self, context: Context, args):
@@ -289,7 +289,7 @@ class CampaignStore:
                 return None, CustomMassenergizeError("campaign manager already exists!")
             return manager, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_manager(self, context: Context, args):
@@ -308,7 +308,7 @@ class CampaignStore:
 
             return campaign_manager, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -332,7 +332,7 @@ class CampaignStore:
 
             return campaign_manager.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_community(self, context: Context, args):
@@ -368,7 +368,7 @@ class CampaignStore:
             campaign_communities.sort(key=lambda x: x["alias"] or x["community"]["name"])
             return campaign_communities, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_community(self, context: Context, args):
@@ -393,7 +393,7 @@ class CampaignStore:
             campaign_community.delete()
             return campaign_community, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_community(self, context: Context, args):
@@ -420,7 +420,7 @@ class CampaignStore:
 
             return campaign_community.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_technology(self, context: Context, args):
@@ -455,7 +455,7 @@ class CampaignStore:
             return CampaignTechnology.objects.filter(campaign=campaign, is_deleted=False), None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_technology(self, context: Context, args):
@@ -472,7 +472,7 @@ class CampaignStore:
 
             return campaign_technology.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_technology(self, context: Context, args):
@@ -497,7 +497,7 @@ class CampaignStore:
 
             return campaign_technology, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_technology_testimonial(self, context: Context, args):
@@ -554,7 +554,7 @@ class CampaignStore:
 
             return campaign_testimonial, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_technology_testimonial(self, context: Context, args):
@@ -596,7 +596,7 @@ class CampaignStore:
 
             return campaign_technology_testimonial, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_technology_comment(self, context: Context, args):
@@ -636,7 +636,7 @@ class CampaignStore:
             latest_comments = Comment.objects.filter(campaign_technology__id=campaign_technology_id, is_deleted=False).order_by("-created_at")
             return latest_comments[:20], None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_technology_comment(self, context: Context, args):
@@ -653,7 +653,7 @@ class CampaignStore:
 
             return comment.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -666,7 +666,7 @@ class CampaignStore:
 
             return comments, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_technology_testimonials(self, context: Context, args):
@@ -678,7 +678,7 @@ class CampaignStore:
 
             return testimonials.order_by("-created_at"), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_campaign_technology_testimonial(self, context: Context, args):
@@ -702,7 +702,7 @@ class CampaignStore:
 
             return campaign_technology_testimonial, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_technologies(self, context: Context, args):
@@ -714,7 +714,7 @@ class CampaignStore:
 
             return technologies, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_communities(self, context: Context, args):
@@ -725,7 +725,7 @@ class CampaignStore:
             communities = CampaignCommunity.objects.filter(campaign__id=campaign_id, is_deleted=False)
             return communities, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_managers(self, context: Context, args):
@@ -737,7 +737,7 @@ class CampaignStore:
 
             return managers, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_partners(self, context: Context, args):
@@ -768,7 +768,7 @@ class CampaignStore:
             return created_list, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_partners(self, context: Context, args):
@@ -788,7 +788,7 @@ class CampaignStore:
 
             return campaign_partner, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_partners(self, context: Context, args):
@@ -802,7 +802,7 @@ class CampaignStore:
 
             return partners, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_technology_event(self, context: Context, args):
@@ -835,7 +835,7 @@ class CampaignStore:
 
             return created_list, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def generate_campaign_link(self, context: Context, args):
@@ -870,7 +870,7 @@ class CampaignStore:
             generated_link = f"{url}?utm_source={utm_source}&utm_medium={utm_medium}&link_id={campaign_link.id}"
             return {"link": generated_link}, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def campaign_link_visits_count(self, context, args):
@@ -885,7 +885,7 @@ class CampaignStore:
 
             return campaign_link, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_follower(self, context, args):
@@ -925,7 +925,7 @@ class CampaignStore:
 
             return follower, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -963,7 +963,7 @@ class CampaignStore:
 
             return follower, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -986,7 +986,7 @@ class CampaignStore:
 
             return campaign_tech, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_technology_view(self, context, args):
@@ -1015,7 +1015,7 @@ class CampaignStore:
                 view.increase_count()
             return view, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_technology_event(self, context: Context, args):
@@ -1027,7 +1027,7 @@ class CampaignStore:
 
             return events, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_analytics(self, context: Context, args):
@@ -1066,7 +1066,7 @@ class CampaignStore:
             }
             return stats, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1084,7 +1084,7 @@ class CampaignStore:
 
             return like, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def transfer_ownership(self, context: Context, args):
@@ -1113,7 +1113,7 @@ class CampaignStore:
 
             return campaign, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_technology_info(
@@ -1129,7 +1129,7 @@ class CampaignStore:
             return campaign_technology, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_technology_testimonial(
@@ -1145,7 +1145,7 @@ class CampaignStore:
             return campaign_technology_testimonial, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_config(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1162,7 +1162,7 @@ class CampaignStore:
             return config, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_config(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1179,7 +1179,7 @@ class CampaignStore:
             return campaign_config, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_config(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1195,7 +1195,7 @@ class CampaignStore:
             return campaign_config, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_navigation(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1247,7 +1247,7 @@ class CampaignStore:
             return new_campaign, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def track_activity(self, context: Context, args: dict):
@@ -1265,7 +1265,7 @@ class CampaignStore:
             return activity, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1300,7 +1300,7 @@ class CampaignStore:
                 view.increase_count()
             return view, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1323,7 +1323,7 @@ class CampaignStore:
 
             return comment[:20], None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1376,7 +1376,7 @@ class CampaignStore:
 
             return campaign_technology, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1406,7 +1406,7 @@ class CampaignStore:
 
             return to_return, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(str(e))
 
 
@@ -1444,7 +1444,7 @@ class CampaignStore:
             return to_return, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(str(e))
 
 
@@ -1454,7 +1454,7 @@ class CampaignStore:
             vendors = Vendor.objects.filter(is_deleted=False, is_published=True)
             return vendors, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1492,7 +1492,7 @@ class CampaignStore:
 
             return testimonials, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1516,7 +1516,7 @@ class CampaignStore:
 
             return campaign_technology_event, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1553,5 +1553,5 @@ class CampaignStore:
 
             return campaign_managers.order_by("-created_at"), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/campaign.py
+++ b/src/api/store/campaign.py
@@ -39,7 +39,7 @@ from _main_.utils.massenergize_errors import (
 from _main_.utils.context import Context
 from .utils import get_user_from_context
 from django.db.models import Q
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from django.db import transaction
 
@@ -69,7 +69,7 @@ class CampaignStore:
             return campaign, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaigns(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -87,7 +87,7 @@ class CampaignStore:
 
             return campaigns.distinct().order_by("-created_at"), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign(
@@ -156,7 +156,7 @@ class CampaignStore:
             return new_campaign, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaigns(
@@ -197,7 +197,7 @@ class CampaignStore:
 
             return campaigns.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_campaign(
@@ -222,7 +222,7 @@ class CampaignStore:
 
             return campaign_to_delete, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaigns_for_admins(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -248,7 +248,7 @@ class CampaignStore:
             return campaigns.distinct().order_by("-created_at"), None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaigns_for_super_admin(self, context: Context):
@@ -256,7 +256,7 @@ class CampaignStore:
             campaigns = Campaign.objects.filter(is_deleted=False)
             return campaigns.order_by("-created_at"), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_manager(self, context: Context, args):
@@ -289,7 +289,7 @@ class CampaignStore:
                 return None, CustomMassenergizeError("campaign manager already exists!")
             return manager, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_manager(self, context: Context, args):
@@ -308,7 +308,7 @@ class CampaignStore:
 
             return campaign_manager, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -332,7 +332,7 @@ class CampaignStore:
 
             return campaign_manager.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_community(self, context: Context, args):
@@ -368,7 +368,7 @@ class CampaignStore:
             campaign_communities.sort(key=lambda x: x["alias"] or x["community"]["name"])
             return campaign_communities, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_community(self, context: Context, args):
@@ -393,7 +393,7 @@ class CampaignStore:
             campaign_community.delete()
             return campaign_community, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_community(self, context: Context, args):
@@ -420,7 +420,7 @@ class CampaignStore:
 
             return campaign_community.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_technology(self, context: Context, args):
@@ -455,7 +455,7 @@ class CampaignStore:
             return CampaignTechnology.objects.filter(campaign=campaign, is_deleted=False), None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_technology(self, context: Context, args):
@@ -472,7 +472,7 @@ class CampaignStore:
 
             return campaign_technology.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_technology(self, context: Context, args):
@@ -497,7 +497,7 @@ class CampaignStore:
 
             return campaign_technology, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_technology_testimonial(self, context: Context, args):
@@ -554,7 +554,7 @@ class CampaignStore:
 
             return campaign_testimonial, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_technology_testimonial(self, context: Context, args):
@@ -596,7 +596,7 @@ class CampaignStore:
 
             return campaign_technology_testimonial, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_technology_comment(self, context: Context, args):
@@ -636,7 +636,7 @@ class CampaignStore:
             latest_comments = Comment.objects.filter(campaign_technology__id=campaign_technology_id, is_deleted=False).order_by("-created_at")
             return latest_comments[:20], None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_technology_comment(self, context: Context, args):
@@ -653,7 +653,7 @@ class CampaignStore:
 
             return comment.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -666,7 +666,7 @@ class CampaignStore:
 
             return comments, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_technology_testimonials(self, context: Context, args):
@@ -678,7 +678,7 @@ class CampaignStore:
 
             return testimonials.order_by("-created_at"), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_campaign_technology_testimonial(self, context: Context, args):
@@ -702,7 +702,7 @@ class CampaignStore:
 
             return campaign_technology_testimonial, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_technologies(self, context: Context, args):
@@ -714,7 +714,7 @@ class CampaignStore:
 
             return technologies, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_communities(self, context: Context, args):
@@ -725,7 +725,7 @@ class CampaignStore:
             communities = CampaignCommunity.objects.filter(campaign__id=campaign_id, is_deleted=False)
             return communities, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_managers(self, context: Context, args):
@@ -737,7 +737,7 @@ class CampaignStore:
 
             return managers, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_partners(self, context: Context, args):
@@ -768,7 +768,7 @@ class CampaignStore:
             return created_list, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def remove_campaign_partners(self, context: Context, args):
@@ -788,7 +788,7 @@ class CampaignStore:
 
             return campaign_partner, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_partners(self, context: Context, args):
@@ -802,7 +802,7 @@ class CampaignStore:
 
             return partners, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_technology_event(self, context: Context, args):
@@ -835,7 +835,7 @@ class CampaignStore:
 
             return created_list, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def generate_campaign_link(self, context: Context, args):
@@ -870,7 +870,7 @@ class CampaignStore:
             generated_link = f"{url}?utm_source={utm_source}&utm_medium={utm_medium}&link_id={campaign_link.id}"
             return {"link": generated_link}, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def campaign_link_visits_count(self, context, args):
@@ -885,7 +885,7 @@ class CampaignStore:
 
             return campaign_link, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_follower(self, context, args):
@@ -925,7 +925,7 @@ class CampaignStore:
 
             return follower, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -963,7 +963,7 @@ class CampaignStore:
 
             return follower, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -986,7 +986,7 @@ class CampaignStore:
 
             return campaign_tech, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_campaign_technology_view(self, context, args):
@@ -1015,7 +1015,7 @@ class CampaignStore:
                 view.increase_count()
             return view, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_campaign_technology_event(self, context: Context, args):
@@ -1027,7 +1027,7 @@ class CampaignStore:
 
             return events, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_analytics(self, context: Context, args):
@@ -1066,7 +1066,7 @@ class CampaignStore:
             }
             return stats, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1084,7 +1084,7 @@ class CampaignStore:
 
             return like, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def transfer_ownership(self, context: Context, args):
@@ -1113,7 +1113,7 @@ class CampaignStore:
 
             return campaign, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_technology_info(
@@ -1129,7 +1129,7 @@ class CampaignStore:
             return campaign_technology, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_technology_testimonial(
@@ -1145,7 +1145,7 @@ class CampaignStore:
             return campaign_technology_testimonial, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_config(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1162,7 +1162,7 @@ class CampaignStore:
             return config, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_campaign_config(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1179,7 +1179,7 @@ class CampaignStore:
             return campaign_config, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_campaign_config(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1195,7 +1195,7 @@ class CampaignStore:
             return campaign_config, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_campaign_navigation(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1247,7 +1247,7 @@ class CampaignStore:
             return new_campaign, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def track_activity(self, context: Context, args: dict):
@@ -1265,7 +1265,7 @@ class CampaignStore:
             return activity, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1300,7 +1300,7 @@ class CampaignStore:
                 view.increase_count()
             return view, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1323,7 +1323,7 @@ class CampaignStore:
 
             return comment[:20], None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1376,7 +1376,7 @@ class CampaignStore:
 
             return campaign_technology, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1406,7 +1406,7 @@ class CampaignStore:
 
             return to_return, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(str(e))
 
 
@@ -1444,7 +1444,7 @@ class CampaignStore:
             return to_return, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(str(e))
 
 
@@ -1454,7 +1454,7 @@ class CampaignStore:
             vendors = Vendor.objects.filter(is_deleted=False, is_published=True)
             return vendors, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1492,7 +1492,7 @@ class CampaignStore:
 
             return testimonials, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1516,7 +1516,7 @@ class CampaignStore:
 
             return campaign_technology_event, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1553,5 +1553,5 @@ class CampaignStore:
 
             return campaign_managers.order_by("-created_at"), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/campaign_account.py
+++ b/src/api/store/campaign_account.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.context import Context
 from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergizeAPIError
 from api.store.utils import get_user_from_context
@@ -31,7 +31,7 @@ class CampaignAccountStore:
             account = CampaignAccount.objects.create(**args)
             return account, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
     
@@ -47,7 +47,7 @@ class CampaignAccountStore:
             else:
                 return None, CustomMassenergizeError("id not provided")
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -61,7 +61,7 @@ class CampaignAccountStore:
             account.update(is_deleted=True)
             return account.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -70,7 +70,7 @@ class CampaignAccountStore:
             accounts = CampaignAccount.objects.filter(is_deleted=False)
             return accounts, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -83,7 +83,7 @@ class CampaignAccountStore:
 
             return account.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -104,7 +104,7 @@ class CampaignAccountStore:
             account_admin = CampaignAccountAdmin.objects.create(account=account.first(), user=user, role=role)
             return account_admin, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -118,7 +118,7 @@ class CampaignAccountStore:
             admin.update(is_deleted=True)
             return admin.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -132,6 +132,6 @@ class CampaignAccountStore:
             admin.update(**args)
             return admin.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 

--- a/src/api/store/campaign_account.py
+++ b/src/api/store/campaign_account.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.context import Context
 from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergizeAPIError
 from api.store.utils import get_user_from_context
@@ -31,7 +31,7 @@ class CampaignAccountStore:
             account = CampaignAccount.objects.create(**args)
             return account, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
     
@@ -47,7 +47,7 @@ class CampaignAccountStore:
             else:
                 return None, CustomMassenergizeError("id not provided")
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -61,7 +61,7 @@ class CampaignAccountStore:
             account.update(is_deleted=True)
             return account.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -70,7 +70,7 @@ class CampaignAccountStore:
             accounts = CampaignAccount.objects.filter(is_deleted=False)
             return accounts, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -83,7 +83,7 @@ class CampaignAccountStore:
 
             return account.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -104,7 +104,7 @@ class CampaignAccountStore:
             account_admin = CampaignAccountAdmin.objects.create(account=account.first(), user=user, role=role)
             return account_admin, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -118,7 +118,7 @@ class CampaignAccountStore:
             admin.update(is_deleted=True)
             return admin.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -132,6 +132,6 @@ class CampaignAccountStore:
             admin.update(**args)
             return admin.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -4,8 +4,7 @@ from typing import Tuple
 
 import zipcodes
 from django.db.models import Q
-from sentry_sdk import capture_exception, capture_message
-
+from _main_.utils.massenergize_logger import logger
 from _main_.settings import IS_PROD, SLACK_SUPER_ADMINS_WEBHOOK_URL
 from _main_.utils.constants import PUBLIC_EMAIL_DOMAINS, RESERVED_SUBDOMAIN_LIST
 from _main_.utils.context import Context
@@ -566,7 +565,7 @@ class CommunityStore:
 
             return community, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def join_community(
@@ -595,7 +594,7 @@ class CommunityStore:
 
             return user, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def leave_community(
@@ -624,7 +623,7 @@ class CommunityStore:
 
             return user, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def list_communities(
@@ -699,7 +698,7 @@ class CommunityStore:
 
             return communities, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def create_community(
@@ -904,7 +903,7 @@ class CommunityStore:
                 reserved = Subdomain.objects.filter(name=args.get("subdomain")).first()
                 if reserved:
                     reserved.delete()
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def update_community(
@@ -1026,7 +1025,7 @@ class CommunityStore:
             return community, None
 
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def delete_community(self, args, context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1061,7 +1060,7 @@ class CommunityStore:
             # ----------------------------------------------------------------
             return communities, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def fetch_admins_of(
@@ -1103,7 +1102,7 @@ class CommunityStore:
                 return [], None
 
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def list_communities_for_super_admin(self, context, args={}):
@@ -1120,7 +1119,7 @@ class CommunityStore:
             communities = list(Community.objects.filter(is_deleted=False, *filter_params).order_by('name'))
             return communities, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def add_custom_website(self, context, args):
@@ -1148,7 +1147,7 @@ class CommunityStore:
 
             return community_website, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def get_graphs(self, context, community_id):
@@ -1158,7 +1157,7 @@ class CommunityStore:
             graphs = Graph.objects.filter(is_deleted=False, community__id=community_id)
             return graphs, None
         except Exception as e:
-            capture_exception(e)
+            logger.error(e)
             return None, CustomMassenergizeError(e)
 
     def list_actions_completed(
@@ -1210,7 +1209,7 @@ class CommunityStore:
 
             return actions_completed, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_community_features(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1237,7 +1236,7 @@ class CommunityStore:
             return obj, None
         
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def request_feature_for_community(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1274,7 +1273,7 @@ class CommunityStore:
             return {"key": feature_flag.key, "notes": feature_flag.notes, "is_enabled": should_enable, "name":feature_flag.name}, None
         
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_community_notification_settings(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1328,7 +1327,7 @@ class CommunityStore:
             return {"feature_is_enabled": True, **notification_setting.simple_json()}, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_community_notification_settings(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -4,7 +4,7 @@ from typing import Tuple
 
 import zipcodes
 from django.db.models import Q
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.settings import IS_PROD, SLACK_SUPER_ADMINS_WEBHOOK_URL
 from _main_.utils.constants import PUBLIC_EMAIL_DOMAINS, RESERVED_SUBDOMAIN_LIST
 from _main_.utils.context import Context
@@ -565,7 +565,7 @@ class CommunityStore:
 
             return community, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def join_community(
@@ -594,7 +594,7 @@ class CommunityStore:
 
             return user, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def leave_community(
@@ -623,7 +623,7 @@ class CommunityStore:
 
             return user, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def list_communities(
@@ -698,7 +698,7 @@ class CommunityStore:
 
             return communities, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def create_community(
@@ -903,7 +903,7 @@ class CommunityStore:
                 reserved = Subdomain.objects.filter(name=args.get("subdomain")).first()
                 if reserved:
                     reserved.delete()
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def update_community(
@@ -1025,7 +1025,7 @@ class CommunityStore:
             return community, None
 
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def delete_community(self, args, context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1060,7 +1060,7 @@ class CommunityStore:
             # ----------------------------------------------------------------
             return communities, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def fetch_admins_of(
@@ -1102,7 +1102,7 @@ class CommunityStore:
                 return [], None
 
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def list_communities_for_super_admin(self, context, args={}):
@@ -1119,7 +1119,7 @@ class CommunityStore:
             communities = list(Community.objects.filter(is_deleted=False, *filter_params).order_by('name'))
             return communities, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def add_custom_website(self, context, args):
@@ -1147,7 +1147,7 @@ class CommunityStore:
 
             return community_website, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def get_graphs(self, context, community_id):
@@ -1157,7 +1157,7 @@ class CommunityStore:
             graphs = Graph.objects.filter(is_deleted=False, community__id=community_id)
             return graphs, None
         except Exception as e:
-            logger.error(e)
+            log.error(e)
             return None, CustomMassenergizeError(e)
 
     def list_actions_completed(
@@ -1209,7 +1209,7 @@ class CommunityStore:
 
             return actions_completed, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_community_features(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1236,7 +1236,7 @@ class CommunityStore:
             return obj, None
         
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def request_feature_for_community(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1273,7 +1273,7 @@ class CommunityStore:
             return {"key": feature_flag.key, "notes": feature_flag.notes, "is_enabled": should_enable, "name":feature_flag.name}, None
         
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_community_notification_settings(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1327,7 +1327,7 @@ class CommunityStore:
             return {"feature_is_enabled": True, **notification_setting.simple_json()}, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_community_notification_settings(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:

--- a/src/api/store/deviceprofile.py
+++ b/src/api/store/deviceprofile.py
@@ -3,7 +3,7 @@ from database.models import UserProfile, DeviceProfile, Location, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
 from _main_.settings import DEBUG
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class DeviceStore:
@@ -19,7 +19,7 @@ class DeviceStore:
       return device, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def __device_attr_handler(self, new_device, args):
@@ -53,7 +53,7 @@ class DeviceStore:
       return new_device, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def log_device(self, context: Context, args, location) -> Tuple[dict, MassEnergizeAPIError]:
@@ -151,7 +151,7 @@ class DeviceStore:
       if device:
         device.delete()
       # print(e)
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def metric_anonymous_users(self) -> Tuple[dict, MassEnergizeAPIError]:
@@ -162,7 +162,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def metric_anonymous_community_users(self, community_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -173,7 +173,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def metric_user_profiles(self) -> Tuple[dict, MassEnergizeAPIError]:
@@ -184,7 +184,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
     
   def metric_community_profiles(self, community_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -195,7 +195,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   # def monthly_profiles(self, community_id, start_date, end_date, delta):
@@ -240,7 +240,7 @@ class DeviceStore:
       return data, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
       
   def update_device(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -259,7 +259,7 @@ class DeviceStore:
       return new_device, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def delete_device(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -270,5 +270,5 @@ class DeviceStore:
       return devices.first(), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/deviceprofile.py
+++ b/src/api/store/deviceprofile.py
@@ -3,7 +3,7 @@ from database.models import UserProfile, DeviceProfile, Location, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
 from _main_.settings import DEBUG
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class DeviceStore:
@@ -19,7 +19,7 @@ class DeviceStore:
       return device, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def __device_attr_handler(self, new_device, args):
@@ -53,7 +53,7 @@ class DeviceStore:
       return new_device, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def log_device(self, context: Context, args, location) -> Tuple[dict, MassEnergizeAPIError]:
@@ -151,7 +151,7 @@ class DeviceStore:
       if device:
         device.delete()
       # print(e)
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def metric_anonymous_users(self) -> Tuple[dict, MassEnergizeAPIError]:
@@ -162,7 +162,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def metric_anonymous_community_users(self, community_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -173,7 +173,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def metric_user_profiles(self) -> Tuple[dict, MassEnergizeAPIError]:
@@ -184,7 +184,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
     
   def metric_community_profiles(self, community_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -195,7 +195,7 @@ class DeviceStore:
       return metric, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   # def monthly_profiles(self, community_id, start_date, end_date, delta):
@@ -240,7 +240,7 @@ class DeviceStore:
       return data, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
       
   def update_device(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -259,7 +259,7 @@ class DeviceStore:
       return new_device, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def delete_device(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -270,5 +270,5 @@ class DeviceStore:
       return devices.first(), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/download.py
+++ b/src/api/store/download.py
@@ -46,7 +46,7 @@ from _main_.utils.constants import ADMIN_URL_ROOT, COMMUNITY_URL_ROOT
 from api.store.tag_collection import TagCollectionStore
 from api.store.deviceprofile import DeviceStore
 from django.db.models import Q
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 from django.utils import timezone
@@ -1512,7 +1512,7 @@ class DownloadStore:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
         except Exception as e:
             print(str(e))
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1539,7 +1539,7 @@ class DownloadStore:
             else:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
 
     #For All Communities CSV - for superadmin, information about each community
@@ -1551,7 +1551,7 @@ class DownloadStore:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
             return (self._all_communities_download(), None), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
 
     #For Teams CSV --  information about the Teams in a given community
@@ -1573,7 +1573,7 @@ class DownloadStore:
             else:
                 return EMPTY_DOWNLOAD, InvalidResourceError()
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
 
 
@@ -1596,7 +1596,7 @@ class DownloadStore:
                     self._all_metrics_download(context, args), 
                     None,), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1618,7 +1618,7 @@ class DownloadStore:
             
             
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1637,7 +1637,7 @@ class DownloadStore:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
         except Exception as e:
             print("community_pagemap_exception: " + str(e))
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1693,7 +1693,7 @@ class DownloadStore:
             return (self._campaign_follows_download(campaign), None), None
             
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1745,7 +1745,7 @@ class DownloadStore:
             return (self._campaign_likes_download(campaign), None), None
             
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
     
 
@@ -1776,7 +1776,7 @@ class DownloadStore:
             
             return (self._campaign_link_performance_download(campaign), None), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1802,7 +1802,7 @@ class DownloadStore:
             return (data, None), None
             
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1834,7 +1834,7 @@ class DownloadStore:
             return (self._campaign_interaction_performance_download(campaign), None), None
             
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1977,7 +1977,7 @@ class DownloadStore:
 
             return (wb, campaign.title), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 

--- a/src/api/store/download.py
+++ b/src/api/store/download.py
@@ -46,7 +46,7 @@ from _main_.utils.constants import ADMIN_URL_ROOT, COMMUNITY_URL_ROOT
 from api.store.tag_collection import TagCollectionStore
 from api.store.deviceprofile import DeviceStore
 from django.db.models import Q
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 from django.utils import timezone
@@ -1512,7 +1512,7 @@ class DownloadStore:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
         except Exception as e:
             print(str(e))
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1539,7 +1539,7 @@ class DownloadStore:
             else:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
 
     #For All Communities CSV - for superadmin, information about each community
@@ -1551,7 +1551,7 @@ class DownloadStore:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
             return (self._all_communities_download(), None), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
 
     #For Teams CSV --  information about the Teams in a given community
@@ -1573,7 +1573,7 @@ class DownloadStore:
             else:
                 return EMPTY_DOWNLOAD, InvalidResourceError()
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
 
 
@@ -1596,7 +1596,7 @@ class DownloadStore:
                     self._all_metrics_download(context, args), 
                     None,), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1618,7 +1618,7 @@ class DownloadStore:
             
             
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1637,7 +1637,7 @@ class DownloadStore:
                 return EMPTY_DOWNLOAD, NotAuthorizedError()
         except Exception as e:
             print("community_pagemap_exception: " + str(e))
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1693,7 +1693,7 @@ class DownloadStore:
             return (self._campaign_follows_download(campaign), None), None
             
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1745,7 +1745,7 @@ class DownloadStore:
             return (self._campaign_likes_download(campaign), None), None
             
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
     
 
@@ -1776,7 +1776,7 @@ class DownloadStore:
             
             return (self._campaign_link_performance_download(campaign), None), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1802,7 +1802,7 @@ class DownloadStore:
             return (data, None), None
             
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1834,7 +1834,7 @@ class DownloadStore:
             return (self._campaign_interaction_performance_download(campaign), None), None
             
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 
@@ -1977,7 +1977,7 @@ class DownloadStore:
 
             return (wb, campaign.title), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return EMPTY_DOWNLOAD, CustomMassenergizeError(e)
         
 

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -14,7 +14,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
     NotAuthorizedError
 from django.db.models import Q, F
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 from database.utils.settings.model_constants.events import EventConstants
 from .utils import get_user_from_context, get_user_or_die, get_new_title
@@ -98,7 +98,7 @@ class EventStore:
                 return None, InvalidResourceError()
             return event, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def copy_event(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -165,7 +165,7 @@ class EventStore:
             # ----------------------------------------------------------------
             return new_event, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_recurring_event_exceptions(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -207,7 +207,7 @@ class EventStore:
 
             return exceptions, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_events(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -376,7 +376,7 @@ class EventStore:
             # ----------------------------------------------------------------
             return new_event, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_event(self, context: Context, args, user_submitted) -> Tuple[dict, MassEnergizeAPIError]:
@@ -640,7 +640,7 @@ class EventStore:
             return event, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_recurring_event_date(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -766,7 +766,7 @@ class EventStore:
                 raise Exception("Rank and ID not provided to events.rank")
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_event(self, context: Context, event_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -789,7 +789,7 @@ class EventStore:
             # ----------------------------------------------------------------
             return event, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def fetch_other_events_for_cadmin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -833,7 +833,7 @@ class EventStore:
                                                                             is_global=False)).distinct().order_by("-id")
             return events.filter(*filter_params).distinct(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_events_for_community_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -872,7 +872,7 @@ class EventStore:
                 'tags')
             return events, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_events_for_super_admin(self, context: Context):
@@ -885,7 +885,7 @@ class EventStore:
                 name__contains=" (rescheduled)").select_related('image', 'community').prefetch_related('tags')
             return events, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_rsvp_list(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -906,7 +906,7 @@ class EventStore:
                 return None, InvalidResourceError()
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_rsvp_status(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -924,7 +924,7 @@ class EventStore:
             else:
                 return None, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def rsvp_update(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -951,7 +951,7 @@ class EventStore:
             return event_attendee, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def rsvp_remove(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -972,7 +972,7 @@ class EventStore:
 
             return result, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def share_event(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -990,7 +990,7 @@ class EventStore:
 
             return event, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
     
     def create_event_reminder_settings(self, context: Context, args) -> Tuple[EventNudgeSetting, MassEnergizeAPIError]:
@@ -1036,7 +1036,7 @@ class EventStore:
         
         
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1059,5 +1059,5 @@ class EventStore:
             return {"success": True}, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(str(e))

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -14,7 +14,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
     NotAuthorizedError
 from django.db.models import Q, F
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 from database.utils.settings.model_constants.events import EventConstants
 from .utils import get_user_from_context, get_user_or_die, get_new_title
@@ -98,7 +98,7 @@ class EventStore:
                 return None, InvalidResourceError()
             return event, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def copy_event(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -165,7 +165,7 @@ class EventStore:
             # ----------------------------------------------------------------
             return new_event, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_recurring_event_exceptions(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -207,7 +207,7 @@ class EventStore:
 
             return exceptions, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_events(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -376,7 +376,7 @@ class EventStore:
             # ----------------------------------------------------------------
             return new_event, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_event(self, context: Context, args, user_submitted) -> Tuple[dict, MassEnergizeAPIError]:
@@ -640,7 +640,7 @@ class EventStore:
             return event, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_recurring_event_date(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -766,7 +766,7 @@ class EventStore:
                 raise Exception("Rank and ID not provided to events.rank")
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_event(self, context: Context, event_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -789,7 +789,7 @@ class EventStore:
             # ----------------------------------------------------------------
             return event, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def fetch_other_events_for_cadmin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -833,7 +833,7 @@ class EventStore:
                                                                             is_global=False)).distinct().order_by("-id")
             return events.filter(*filter_params).distinct(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_events_for_community_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -872,7 +872,7 @@ class EventStore:
                 'tags')
             return events, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_events_for_super_admin(self, context: Context):
@@ -885,7 +885,7 @@ class EventStore:
                 name__contains=" (rescheduled)").select_related('image', 'community').prefetch_related('tags')
             return events, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_rsvp_list(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -906,7 +906,7 @@ class EventStore:
                 return None, InvalidResourceError()
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_rsvp_status(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -924,7 +924,7 @@ class EventStore:
             else:
                 return None, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def rsvp_update(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -951,7 +951,7 @@ class EventStore:
             return event_attendee, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def rsvp_remove(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -972,7 +972,7 @@ class EventStore:
 
             return result, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def share_event(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -990,7 +990,7 @@ class EventStore:
 
             return event, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
     
     def create_event_reminder_settings(self, context: Context, args) -> Tuple[EventNudgeSetting, MassEnergizeAPIError]:
@@ -1036,7 +1036,7 @@ class EventStore:
         
         
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
 
@@ -1059,5 +1059,5 @@ class EventStore:
             return {"success": True}, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(str(e))

--- a/src/api/store/export.py
+++ b/src/api/store/export.py
@@ -2,7 +2,7 @@ from database.models import Team, UserProfile
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class TeamStore:
@@ -56,5 +56,5 @@ class TeamStore:
       teams = Team.objects.all()
       return teams, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/export.py
+++ b/src/api/store/export.py
@@ -2,7 +2,7 @@ from database.models import Team, UserProfile
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class TeamStore:
@@ -56,5 +56,5 @@ class TeamStore:
       teams = Team.objects.all()
       return teams, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/feature_flag.py
+++ b/src/api/store/feature_flag.py
@@ -15,7 +15,7 @@ from .utils import (
     get_community,
     get_user,
 )
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 
@@ -32,7 +32,7 @@ class FeatureFlagStore:
                 return None, InvalidResourceError()
             return ff, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_feature_flag(self, ctx: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -50,7 +50,7 @@ class FeatureFlagStore:
             return flag, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_feature_flag(
@@ -81,7 +81,7 @@ class FeatureFlagStore:
             return flag, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_feature_flags(
@@ -152,7 +152,7 @@ class FeatureFlagStore:
             print("== ff ===",ff)
             return ff, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def listForSuperAdmins(
@@ -164,7 +164,7 @@ class FeatureFlagStore:
 
             return ff, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_feature_flag(
@@ -175,5 +175,5 @@ class FeatureFlagStore:
             ff = FeatureFlag.objects.filter(id=id).first().delete()
             return id, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/feature_flag.py
+++ b/src/api/store/feature_flag.py
@@ -15,7 +15,7 @@ from .utils import (
     get_community,
     get_user,
 )
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 
@@ -32,7 +32,7 @@ class FeatureFlagStore:
                 return None, InvalidResourceError()
             return ff, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_feature_flag(self, ctx: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -50,7 +50,7 @@ class FeatureFlagStore:
             return flag, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_feature_flag(
@@ -81,7 +81,7 @@ class FeatureFlagStore:
             return flag, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_feature_flags(
@@ -152,7 +152,7 @@ class FeatureFlagStore:
             print("== ff ===",ff)
             return ff, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def listForSuperAdmins(
@@ -164,7 +164,7 @@ class FeatureFlagStore:
 
             return ff, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_feature_flag(
@@ -175,5 +175,5 @@ class FeatureFlagStore:
             ff = FeatureFlag.objects.filter(id=id).first().delete()
             return id, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/goal.py
+++ b/src/api/store/goal.py
@@ -1,7 +1,7 @@
 from database.models import Goal, UserProfile, Team, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from django.db.models import F
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class GoalStore:
@@ -13,7 +13,7 @@ class GoalStore:
       goal = Goal.objects.get(id=goal_id)
       return goal, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, InvalidResourceError()
 
 
@@ -55,7 +55,7 @@ class GoalStore:
 
       return goals, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -95,7 +95,7 @@ class GoalStore:
 
       return new_goal, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def update_goal(self, goal_id, args) -> Tuple[Goal, MassEnergizeAPIError]:
@@ -113,7 +113,7 @@ class GoalStore:
       goal.update(**args)
       return goal.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def delete_goal(self, goal_id) -> Tuple[Goal, MassEnergizeAPIError]:
@@ -126,7 +126,7 @@ class GoalStore:
         return None, InvalidResourceError()
       return goals_to_delete.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def copy_goal(self, goal_id) -> Tuple[Goal, MassEnergizeAPIError]:
@@ -142,7 +142,7 @@ class GoalStore:
       new_goal.save()
       return new_goal, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -183,7 +183,7 @@ class GoalStore:
       return goals, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       import traceback
       traceback.print_exc()
       return None, CustomMassenergizeError(e)
@@ -194,7 +194,7 @@ class GoalStore:
       goals = Goal.objects.filter(is_deleted=False)
       return goals, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -206,7 +206,7 @@ class GoalStore:
         return None, InvalidResourceError()
       return goals_to_incr.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -218,5 +218,5 @@ class GoalStore:
         return None, InvalidResourceError()
       return goals_to_decrease.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/goal.py
+++ b/src/api/store/goal.py
@@ -1,7 +1,7 @@
 from database.models import Goal, UserProfile, Team, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from django.db.models import F
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class GoalStore:
@@ -13,7 +13,7 @@ class GoalStore:
       goal = Goal.objects.get(id=goal_id)
       return goal, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, InvalidResourceError()
 
 
@@ -55,7 +55,7 @@ class GoalStore:
 
       return goals, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -95,7 +95,7 @@ class GoalStore:
 
       return new_goal, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def update_goal(self, goal_id, args) -> Tuple[Goal, MassEnergizeAPIError]:
@@ -113,7 +113,7 @@ class GoalStore:
       goal.update(**args)
       return goal.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def delete_goal(self, goal_id) -> Tuple[Goal, MassEnergizeAPIError]:
@@ -126,7 +126,7 @@ class GoalStore:
         return None, InvalidResourceError()
       return goals_to_delete.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def copy_goal(self, goal_id) -> Tuple[Goal, MassEnergizeAPIError]:
@@ -142,7 +142,7 @@ class GoalStore:
       new_goal.save()
       return new_goal, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -183,7 +183,7 @@ class GoalStore:
       return goals, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       import traceback
       traceback.print_exc()
       return None, CustomMassenergizeError(e)
@@ -194,7 +194,7 @@ class GoalStore:
       goals = Goal.objects.filter(is_deleted=False)
       return goals, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -206,7 +206,7 @@ class GoalStore:
         return None, InvalidResourceError()
       return goals_to_incr.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -218,5 +218,5 @@ class GoalStore:
         return None, InvalidResourceError()
       return goals_to_decrease.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/graph.py
+++ b/src/api/store/graph.py
@@ -5,7 +5,7 @@ from _main_.utils.context import Context
 from django.db.models import Q, prefetch_related_objects
 from api.store.team import get_team_users
 from .utils import get_community_or_die, unique_media_filename
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from api.services.utils import send_slack_message
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, RUN_SERVER_LOCALLY, IS_PROD, IS_CANARY
@@ -57,7 +57,7 @@ class GraphStore:
         return None, InvalidResourceError()
       return graph, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -79,7 +79,7 @@ class GraphStore:
 
       return graphs, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -123,7 +123,7 @@ class GraphStore:
       return res, None
       
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -170,7 +170,7 @@ class GraphStore:
       return res, None
         
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -200,7 +200,7 @@ class GraphStore:
         "data": res
       }, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -250,7 +250,7 @@ class GraphStore:
     
       return new_graph, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -302,7 +302,7 @@ class GraphStore:
 
       return None, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -331,7 +331,7 @@ class GraphStore:
     except Exception as e:
       if IS_PROD or IS_CANARY:
         send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": str(e)+str(context)}) 
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def delete_data(self, context:Context, data_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -339,7 +339,7 @@ class GraphStore:
       result = Data.objects.filter(pk=data_id).delete()
       return result, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -349,7 +349,7 @@ class GraphStore:
       graphs.update(is_deleted=True, is_published=False)
       return graphs.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -382,7 +382,7 @@ class GraphStore:
       }, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -407,7 +407,7 @@ class GraphStore:
       }, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def debug_data_fix(self) -> None:

--- a/src/api/store/graph.py
+++ b/src/api/store/graph.py
@@ -5,7 +5,7 @@ from _main_.utils.context import Context
 from django.db.models import Q, prefetch_related_objects
 from api.store.team import get_team_users
 from .utils import get_community_or_die, unique_media_filename
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from api.services.utils import send_slack_message
 from _main_.settings import SLACK_SUPER_ADMINS_WEBHOOK_URL, RUN_SERVER_LOCALLY, IS_PROD, IS_CANARY
@@ -57,7 +57,7 @@ class GraphStore:
         return None, InvalidResourceError()
       return graph, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -79,7 +79,7 @@ class GraphStore:
 
       return graphs, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -123,7 +123,7 @@ class GraphStore:
       return res, None
       
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -170,7 +170,7 @@ class GraphStore:
       return res, None
         
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -200,7 +200,7 @@ class GraphStore:
         "data": res
       }, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -250,7 +250,7 @@ class GraphStore:
     
       return new_graph, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -302,7 +302,7 @@ class GraphStore:
 
       return None, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -331,7 +331,7 @@ class GraphStore:
     except Exception as e:
       if IS_PROD or IS_CANARY:
         send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": str(e)+str(context)}) 
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def delete_data(self, context:Context, data_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -339,7 +339,7 @@ class GraphStore:
       result = Data.objects.filter(pk=data_id).delete()
       return result, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -349,7 +349,7 @@ class GraphStore:
       graphs.update(is_deleted=True, is_published=False)
       return graphs.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -382,7 +382,7 @@ class GraphStore:
       }, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -407,7 +407,7 @@ class GraphStore:
       }, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def debug_data_fix(self) -> None:

--- a/src/api/store/media_library.py
+++ b/src/api/store/media_library.py
@@ -16,7 +16,7 @@ from api.store.common import (
     resolve_relations,
     summarize_duplicates_into_csv,
 )
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.context import Context
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
@@ -45,7 +45,7 @@ class MediaLibraryStore:
             string = read_image_from_s3(image.file.name)
             return string, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def print_duplicates(self, args, context: Context):
@@ -174,7 +174,7 @@ class MediaLibraryStore:
             return media, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def find_images(self, args, _):

--- a/src/api/store/media_library.py
+++ b/src/api/store/media_library.py
@@ -16,7 +16,7 @@ from api.store.common import (
     resolve_relations,
     summarize_duplicates_into_csv,
 )
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.context import Context
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
@@ -45,7 +45,7 @@ class MediaLibraryStore:
             string = read_image_from_s3(image.file.name)
             return string, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def print_duplicates(self, args, context: Context):
@@ -174,7 +174,7 @@ class MediaLibraryStore:
             return media, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def find_images(self, args, _):

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -16,7 +16,7 @@ from _main_.utils.context import Context
 from .utils import get_admin_communities, get_user_from_context, unique_media_filename
 from _main_.utils.context import Context
 from .utils import get_community, get_user
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from django.db.models import Q
 from celery.result import AsyncResult
@@ -72,7 +72,7 @@ class MessageStore:
             return message, None
         
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def reply_from_team_admin(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -88,7 +88,7 @@ class MessageStore:
 
             return message, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def message_admin(
@@ -153,7 +153,7 @@ class MessageStore:
             return new_message, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def message_team_admin(
@@ -191,7 +191,7 @@ class MessageStore:
             return new_message, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_message_to_team_admin(
@@ -230,7 +230,7 @@ class MessageStore:
             return message, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def reply_from_community_admin(
@@ -251,7 +251,7 @@ class MessageStore:
 
             return message, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_message(self, message_id, context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -280,7 +280,7 @@ class MessageStore:
             # ----------------------------------------------------------------
             return message, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_community_admin_messages(self, context: Context, args):
@@ -326,7 +326,7 @@ class MessageStore:
     
             return messages, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_team_admin_messages(self, context: Context, args):
@@ -357,7 +357,7 @@ class MessageStore:
                 messages = []
             return messages, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -433,5 +433,5 @@ class MessageStore:
                 return new_message, None
             
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -16,7 +16,7 @@ from _main_.utils.context import Context
 from .utils import get_admin_communities, get_user_from_context, unique_media_filename
 from _main_.utils.context import Context
 from .utils import get_community, get_user
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from django.db.models import Q
 from celery.result import AsyncResult
@@ -72,7 +72,7 @@ class MessageStore:
             return message, None
         
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def reply_from_team_admin(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -88,7 +88,7 @@ class MessageStore:
 
             return message, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def message_admin(
@@ -153,7 +153,7 @@ class MessageStore:
             return new_message, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def message_team_admin(
@@ -191,7 +191,7 @@ class MessageStore:
             return new_message, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_message_to_team_admin(
@@ -230,7 +230,7 @@ class MessageStore:
             return message, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def reply_from_community_admin(
@@ -251,7 +251,7 @@ class MessageStore:
 
             return message, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_message(self, message_id, context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -280,7 +280,7 @@ class MessageStore:
             # ----------------------------------------------------------------
             return message, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_community_admin_messages(self, context: Context, args):
@@ -326,7 +326,7 @@ class MessageStore:
     
             return messages, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_team_admin_messages(self, context: Context, args):
@@ -357,7 +357,7 @@ class MessageStore:
                 messages = []
             return messages, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -433,5 +433,5 @@ class MessageStore:
                 return new_message, None
             
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/misc.py
+++ b/src/api/store/misc.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 from _main_.utils.context import Context
 from _main_.utils.footage.spy import Spy
@@ -61,7 +61,7 @@ class MiscellaneousStore:
             main_menu = Menu.objects.all()
             return main_menu, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def actions_report(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -123,7 +123,7 @@ class MiscellaneousStore:
 
             return {"teams_member_backfill": "done"}, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def backfill_community_members(
@@ -162,7 +162,7 @@ class MiscellaneousStore:
 
             return {"name": "community_member_backfill", "status": "done"}, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def backfill_graph_default_data(self, context: Context, args):
@@ -206,7 +206,7 @@ class MiscellaneousStore:
             return {"graph_default_data": "done"}, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def backfill_real_estate_units(self, context: Context, args):
@@ -373,7 +373,7 @@ class MiscellaneousStore:
             return {"backfill_real_estate_units": "done"}, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_carbon_equivalency(self, args):
@@ -382,7 +382,7 @@ class MiscellaneousStore:
             return new_carbon_equivalency, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_carbon_equivalency(self, args):
@@ -400,7 +400,7 @@ class MiscellaneousStore:
             return carbon_equivalency, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def get_carbon_equivalencies(self, args):

--- a/src/api/store/misc.py
+++ b/src/api/store/misc.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 from _main_.utils.context import Context
 from _main_.utils.footage.spy import Spy
@@ -61,7 +61,7 @@ class MiscellaneousStore:
             main_menu = Menu.objects.all()
             return main_menu, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def actions_report(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -123,7 +123,7 @@ class MiscellaneousStore:
 
             return {"teams_member_backfill": "done"}, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def backfill_community_members(
@@ -162,7 +162,7 @@ class MiscellaneousStore:
 
             return {"name": "community_member_backfill", "status": "done"}, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def backfill_graph_default_data(self, context: Context, args):
@@ -206,7 +206,7 @@ class MiscellaneousStore:
             return {"graph_default_data": "done"}, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def backfill_real_estate_units(self, context: Context, args):
@@ -373,7 +373,7 @@ class MiscellaneousStore:
             return {"backfill_real_estate_units": "done"}, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_carbon_equivalency(self, args):
@@ -382,7 +382,7 @@ class MiscellaneousStore:
             return new_carbon_equivalency, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_carbon_equivalency(self, args):
@@ -400,7 +400,7 @@ class MiscellaneousStore:
             return carbon_equivalency, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def get_carbon_equivalencies(self, args):

--- a/src/api/store/page_settings.py
+++ b/src/api/store/page_settings.py
@@ -2,7 +2,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from api.tests.common import RESET
 from api.utils.api_utils import is_admin_of_community
 from .utils import get_community
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from database.models import Media
 from typing import Tuple
 
@@ -30,7 +30,7 @@ class PageSettingsStore:
         page = page.first()
       return page, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def list_page_settings(self,context, community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -102,5 +102,5 @@ class PageSettingsStore:
       page_settings = self.pageSettingsModel.objects.all()
       return page_settings, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/page_settings.py
+++ b/src/api/store/page_settings.py
@@ -2,7 +2,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from api.tests.common import RESET
 from api.utils.api_utils import is_admin_of_community
 from .utils import get_community
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from database.models import Media
 from typing import Tuple
 
@@ -30,7 +30,7 @@ class PageSettingsStore:
         page = page.first()
       return page, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def list_page_settings(self,context, community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -102,5 +102,5 @@ class PageSettingsStore:
       page_settings = self.pageSettingsModel.objects.all()
       return page_settings, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/page_settings__home.py
+++ b/src/api/store/page_settings__home.py
@@ -5,7 +5,7 @@ from database.models import HomePageSettings, ImageSequence, UserProfile, Media,
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from _main_.utils.metrics import timed
 
@@ -23,7 +23,7 @@ class HomePageSettingsStore:
         return None, InvalidResourceError()
       return home_page_setting, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -153,7 +153,7 @@ class HomePageSettingsStore:
       home_page_setting.refresh_from_db()
       return home_page_setting, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -173,5 +173,5 @@ class HomePageSettingsStore:
       home_page_settings = HomePageSettings.objects.all()
       return home_page_settings, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/page_settings__home.py
+++ b/src/api/store/page_settings__home.py
@@ -5,7 +5,7 @@ from database.models import HomePageSettings, ImageSequence, UserProfile, Media,
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from _main_.utils.metrics import timed
 
@@ -23,7 +23,7 @@ class HomePageSettingsStore:
         return None, InvalidResourceError()
       return home_page_setting, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -153,7 +153,7 @@ class HomePageSettingsStore:
       home_page_setting.refresh_from_db()
       return home_page_setting, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -173,5 +173,5 @@ class HomePageSettingsStore:
       home_page_settings = HomePageSettings.objects.all()
       return home_page_settings, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/partner.py
+++ b/src/api/store/partner.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple
 
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.context import Context
 from _main_.utils.massenergize_errors import CustomMassenergizeError, InvalidResourceError, MassEnergizeAPIError
 from api.utils.api_utils import create_media_file
@@ -22,7 +22,7 @@ class PartnerStore:
             
             return partner, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -31,7 +31,7 @@ class PartnerStore:
             partners = Partner.objects.filter(is_deleted=False)
             return partners, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
     
@@ -44,7 +44,7 @@ class PartnerStore:
             partner.save()
             return partner, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -62,7 +62,7 @@ class PartnerStore:
             else:
                 return None, InvalidResourceError()
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -77,7 +77,7 @@ class PartnerStore:
             partner.update(is_deleted=True)
             return partner.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -86,6 +86,6 @@ class PartnerStore:
             partners = Partner.objects.filter(is_deleted=False)
             return partners, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         

--- a/src/api/store/partner.py
+++ b/src/api/store/partner.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple
 
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.context import Context
 from _main_.utils.massenergize_errors import CustomMassenergizeError, InvalidResourceError, MassEnergizeAPIError
 from api.utils.api_utils import create_media_file
@@ -22,7 +22,7 @@ class PartnerStore:
             
             return partner, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -31,7 +31,7 @@ class PartnerStore:
             partners = Partner.objects.filter(is_deleted=False)
             return partners, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
     
@@ -44,7 +44,7 @@ class PartnerStore:
             partner.save()
             return partner, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -62,7 +62,7 @@ class PartnerStore:
             else:
                 return None, InvalidResourceError()
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -77,7 +77,7 @@ class PartnerStore:
             partner.update(is_deleted=True)
             return partner.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -86,6 +86,6 @@ class PartnerStore:
             partners = Partner.objects.filter(is_deleted=False)
             return partners, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         

--- a/src/api/store/policy.py
+++ b/src/api/store/policy.py
@@ -3,7 +3,7 @@ from database.models import Policy, UserProfile, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, NotAuthorizedError, CustomMassenergizeError
 from _main_.utils.context import Context
 from django.db.models import Q
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class PolicyStore:
@@ -17,7 +17,7 @@ class PolicyStore:
         return None, InvalidResourceError()
       return policy, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_policies(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -25,7 +25,7 @@ class PolicyStore:
       policies = Policy.objects.filter(is_deleted=False)
       return policies, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -43,7 +43,7 @@ class PolicyStore:
         community.save()
       return new_policy, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -70,7 +70,7 @@ class PolicyStore:
           community.save()
       return policy, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -89,7 +89,7 @@ class PolicyStore:
       policies_to_delete.update(is_deleted=True)
       return policies_to_delete.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def copy_policy(self, policy_id) -> Tuple[Policy, MassEnergizeAPIError]:
@@ -105,7 +105,7 @@ class PolicyStore:
       new_policy.save()
       return new_policy, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -122,7 +122,7 @@ class PolicyStore:
       return policies, None
       
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
     
   def list_policies_for_community_admin_old(self, context: Context, community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -152,7 +152,7 @@ class PolicyStore:
       return policies, None
  
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -161,5 +161,5 @@ class PolicyStore:
       policies = Policy.objects.filter(is_deleted=False)
       return policies, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/policy.py
+++ b/src/api/store/policy.py
@@ -3,7 +3,7 @@ from database.models import Policy, UserProfile, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, NotAuthorizedError, CustomMassenergizeError
 from _main_.utils.context import Context
 from django.db.models import Q
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class PolicyStore:
@@ -17,7 +17,7 @@ class PolicyStore:
         return None, InvalidResourceError()
       return policy, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_policies(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -25,7 +25,7 @@ class PolicyStore:
       policies = Policy.objects.filter(is_deleted=False)
       return policies, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -43,7 +43,7 @@ class PolicyStore:
         community.save()
       return new_policy, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -70,7 +70,7 @@ class PolicyStore:
           community.save()
       return policy, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -89,7 +89,7 @@ class PolicyStore:
       policies_to_delete.update(is_deleted=True)
       return policies_to_delete.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def copy_policy(self, policy_id) -> Tuple[Policy, MassEnergizeAPIError]:
@@ -105,7 +105,7 @@ class PolicyStore:
       new_policy.save()
       return new_policy, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -122,7 +122,7 @@ class PolicyStore:
       return policies, None
       
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
     
   def list_policies_for_community_admin_old(self, context: Context, community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -152,7 +152,7 @@ class PolicyStore:
       return policies, None
  
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -161,5 +161,5 @@ class PolicyStore:
       policies = Policy.objects.filter(is_deleted=False)
       return policies, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/subscriber.py
+++ b/src/api/store/subscriber.py
@@ -2,7 +2,7 @@ from api.utils.filter_functions import get_subscribers_filter_params
 from database.models import Subscriber, UserProfile, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 
@@ -17,7 +17,7 @@ class SubscriberStore:
         return None, InvalidResourceError()
       return subscriber, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_subscribers(self,context, community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -38,7 +38,7 @@ class SubscriberStore:
 
       return new_subscriber, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -58,7 +58,7 @@ class SubscriberStore:
           community.save()
       return subscriber, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -71,7 +71,7 @@ class SubscriberStore:
         return None, InvalidResourceError()
       return subscribers_to_delete.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def copy_subscriber(self, subscriber_id) -> Tuple[Subscriber, MassEnergizeAPIError]:
@@ -87,7 +87,7 @@ class SubscriberStore:
       new_subscriber.save()
       return new_subscriber, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -121,7 +121,7 @@ class SubscriberStore:
       return subscribers, None
  
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -131,5 +131,5 @@ class SubscriberStore:
       subscribers = Subscriber.objects.filter(is_deleted=False, *filter_params)
       return subscribers, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/subscriber.py
+++ b/src/api/store/subscriber.py
@@ -2,7 +2,7 @@ from api.utils.filter_functions import get_subscribers_filter_params
 from database.models import Subscriber, UserProfile, Community
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 
@@ -17,7 +17,7 @@ class SubscriberStore:
         return None, InvalidResourceError()
       return subscriber, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_subscribers(self,context, community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -38,7 +38,7 @@ class SubscriberStore:
 
       return new_subscriber, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -58,7 +58,7 @@ class SubscriberStore:
           community.save()
       return subscriber, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -71,7 +71,7 @@ class SubscriberStore:
         return None, InvalidResourceError()
       return subscribers_to_delete.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def copy_subscriber(self, subscriber_id) -> Tuple[Subscriber, MassEnergizeAPIError]:
@@ -87,7 +87,7 @@ class SubscriberStore:
       new_subscriber.save()
       return new_subscriber, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -121,7 +121,7 @@ class SubscriberStore:
       return subscribers, None
  
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -131,5 +131,5 @@ class SubscriberStore:
       subscribers = Subscriber.objects.filter(is_deleted=False, *filter_params)
       return subscribers, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -19,7 +19,7 @@ from _main_.utils.massenergize_errors import (
     CustomMassenergizeError,
 )
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from django.db.models import Q
 import pytz
@@ -322,7 +322,7 @@ class SummaryStore:
             ]
             return summary, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return {}, CustomMassenergizeError(e)
 
     def summary_for_super_admin(self, context: Context):
@@ -346,5 +346,5 @@ class SummaryStore:
             return summary, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -19,7 +19,7 @@ from _main_.utils.massenergize_errors import (
     CustomMassenergizeError,
 )
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from django.db.models import Q
 import pytz
@@ -322,7 +322,7 @@ class SummaryStore:
             ]
             return summary, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return {}, CustomMassenergizeError(e)
 
     def summary_for_super_admin(self, context: Context):
@@ -346,5 +346,5 @@ class SummaryStore:
             return summary, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/tag.py
+++ b/src/api/store/tag.py
@@ -1,6 +1,6 @@
 from database.models import Tag
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class TagStore:
@@ -56,5 +56,5 @@ class TagStore:
       tags = Tag.objects.all()
       return tags, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/tag.py
+++ b/src/api/store/tag.py
@@ -1,6 +1,6 @@
 from database.models import Tag
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, ServerError, CustomMassenergizeError
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class TagStore:
@@ -56,5 +56,5 @@ class TagStore:
       tags = Tag.objects.all()
       return tags, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/tag_collection.py
+++ b/src/api/store/tag_collection.py
@@ -2,7 +2,7 @@ from api.utils.filter_functions import get_tag_collections_filter_params
 from database.models import TagCollection, Tag
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class TagCollectionStore:
@@ -19,7 +19,7 @@ class TagCollectionStore:
         return None, InvalidResourceError()
       return tag_collection, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -28,7 +28,7 @@ class TagCollectionStore:
       tag_collections = TagCollection.objects.filter(is_deleted=False)
       return tag_collections, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -47,7 +47,7 @@ class TagCollectionStore:
 
       return new_tag_collection, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -106,7 +106,7 @@ class TagCollectionStore:
       tag_collection.save()
       return tag_collection, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -118,7 +118,7 @@ class TagCollectionStore:
       tag_collections.delete()
       return {}, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -134,5 +134,5 @@ class TagCollectionStore:
       tag_collections = TagCollection.objects.filter(*filter_params,is_deleted=False )
       return tag_collections, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/tag_collection.py
+++ b/src/api/store/tag_collection.py
@@ -2,7 +2,7 @@ from api.utils.filter_functions import get_tag_collections_filter_params
 from database.models import TagCollection, Tag
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class TagCollectionStore:
@@ -19,7 +19,7 @@ class TagCollectionStore:
         return None, InvalidResourceError()
       return tag_collection, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -28,7 +28,7 @@ class TagCollectionStore:
       tag_collections = TagCollection.objects.filter(is_deleted=False)
       return tag_collections, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -47,7 +47,7 @@ class TagCollectionStore:
 
       return new_tag_collection, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -106,7 +106,7 @@ class TagCollectionStore:
       tag_collection.save()
       return tag_collection, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -118,7 +118,7 @@ class TagCollectionStore:
       tag_collections.delete()
       return {}, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -134,5 +134,5 @@ class TagCollectionStore:
       tag_collections = TagCollection.objects.filter(*filter_params,is_deleted=False )
       return tag_collections, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/task_queue.py
+++ b/src/api/store/task_queue.py
@@ -1,6 +1,6 @@
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from database.models import UserProfile
 from task_queue.models import Task
@@ -19,7 +19,7 @@ class TaskQueueStore:
 
       return task, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -29,7 +29,7 @@ class TaskQueueStore:
         tasks = Task.objects.filter(is_archived=False, **filter_args)
         return tasks, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -51,7 +51,7 @@ class TaskQueueStore:
 
       return task, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(str(e))
 
   def update_task(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -70,7 +70,7 @@ class TaskQueueStore:
       task.create_task()
       return task, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
       
@@ -84,7 +84,7 @@ class TaskQueueStore:
       task.delete()
       return task, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -98,7 +98,7 @@ class TaskQueueStore:
       task.start()
       return task, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -113,6 +113,6 @@ class TaskQueueStore:
       task.stop()
       return task, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 

--- a/src/api/store/task_queue.py
+++ b/src/api/store/task_queue.py
@@ -1,6 +1,6 @@
 from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResourceError, CustomMassenergizeError
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from database.models import UserProfile
 from task_queue.models import Task
@@ -19,7 +19,7 @@ class TaskQueueStore:
 
       return task, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -29,7 +29,7 @@ class TaskQueueStore:
         tasks = Task.objects.filter(is_archived=False, **filter_args)
         return tasks, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -51,7 +51,7 @@ class TaskQueueStore:
 
       return task, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(str(e))
 
   def update_task(self, context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -70,7 +70,7 @@ class TaskQueueStore:
       task.create_task()
       return task, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
       
@@ -84,7 +84,7 @@ class TaskQueueStore:
       task.delete()
       return task, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -98,7 +98,7 @@ class TaskQueueStore:
       task.start()
       return task, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -113,6 +113,6 @@ class TaskQueueStore:
       task.stop()
       return task, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -10,7 +10,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.context import Context
 from _main_.utils.constants import COMMUNITY_URL_ROOT, ADMIN_URL_ROOT
 from .utils import get_community_or_die, get_user_or_die, get_admin_communities, getCarbonScoreFromActionRel, unique_media_filename
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.emailer.send_email import send_massenergize_email, send_massenergize_email_with_attachments
 from carbon_calculator.carbonCalculator import AverageImpact
 from typing import Tuple
@@ -56,7 +56,7 @@ class TeamStore:
         return None, CustomMassenergizeError("Cannot access team until it is approved")
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -68,7 +68,7 @@ class TeamStore:
       team_admins = [a.user for a in team_admins if a.user]
       return team_admins, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
       
@@ -83,7 +83,7 @@ class TeamStore:
         teams = user.team_set.all()
       return teams, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -123,7 +123,7 @@ class TeamStore:
 
       return ans, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -253,7 +253,7 @@ class TeamStore:
         # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       if team:
         team.delete()
       return None, CustomMassenergizeError(e)
@@ -382,7 +382,7 @@ class TeamStore:
       return team, None
     except Exception as e:
       print(str(e))
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
     
 
@@ -415,7 +415,7 @@ class TeamStore:
         # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -434,7 +434,7 @@ class TeamStore:
 
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def leave_team(self, context,args) -> Tuple[Team, MassEnergizeAPIError]:
@@ -451,7 +451,7 @@ class TeamStore:
 
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def add_team_member(self, args,context) -> Tuple[Team, MassEnergizeAPIError]:
@@ -481,7 +481,7 @@ class TeamStore:
       # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def remove_team_member(self, args,context) -> Tuple[Team, MassEnergizeAPIError]:
@@ -507,7 +507,7 @@ class TeamStore:
       # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -558,7 +558,7 @@ class TeamStore:
 
       return res, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, InvalidResourceError()
 
 
@@ -594,7 +594,7 @@ class TeamStore:
       return teams.distinct(), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_teams_for_super_admin(self, context: Context, args):
@@ -615,7 +615,7 @@ class TeamStore:
       return teams.distinct(), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_actions_completed(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -660,6 +660,6 @@ class TeamStore:
       actions_completed = sorted(actions_completed, key=lambda d: d['done_count']*-1)
       return actions_completed, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 

--- a/src/api/store/team.py
+++ b/src/api/store/team.py
@@ -10,7 +10,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.context import Context
 from _main_.utils.constants import COMMUNITY_URL_ROOT, ADMIN_URL_ROOT
 from .utils import get_community_or_die, get_user_or_die, get_admin_communities, getCarbonScoreFromActionRel, unique_media_filename
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.emailer.send_email import send_massenergize_email, send_massenergize_email_with_attachments
 from carbon_calculator.carbonCalculator import AverageImpact
 from typing import Tuple
@@ -56,7 +56,7 @@ class TeamStore:
         return None, CustomMassenergizeError("Cannot access team until it is approved")
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -68,7 +68,7 @@ class TeamStore:
       team_admins = [a.user for a in team_admins if a.user]
       return team_admins, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
       
@@ -83,7 +83,7 @@ class TeamStore:
         teams = user.team_set.all()
       return teams, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -123,7 +123,7 @@ class TeamStore:
 
       return ans, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -253,7 +253,7 @@ class TeamStore:
         # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       if team:
         team.delete()
       return None, CustomMassenergizeError(e)
@@ -382,7 +382,7 @@ class TeamStore:
       return team, None
     except Exception as e:
       print(str(e))
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
     
 
@@ -415,7 +415,7 @@ class TeamStore:
         # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -434,7 +434,7 @@ class TeamStore:
 
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def leave_team(self, context,args) -> Tuple[Team, MassEnergizeAPIError]:
@@ -451,7 +451,7 @@ class TeamStore:
 
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def add_team_member(self, args,context) -> Tuple[Team, MassEnergizeAPIError]:
@@ -481,7 +481,7 @@ class TeamStore:
       # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def remove_team_member(self, args,context) -> Tuple[Team, MassEnergizeAPIError]:
@@ -507,7 +507,7 @@ class TeamStore:
       # ----------------------------------------------------------------
       return team, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -558,7 +558,7 @@ class TeamStore:
 
       return res, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, InvalidResourceError()
 
 
@@ -594,7 +594,7 @@ class TeamStore:
       return teams.distinct(), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_teams_for_super_admin(self, context: Context, args):
@@ -615,7 +615,7 @@ class TeamStore:
       return teams.distinct(), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_actions_completed(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -660,6 +660,6 @@ class TeamStore:
       actions_completed = sorted(actions_completed, key=lambda d: d['done_count']*-1)
       return actions_completed, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 

--- a/src/api/store/technology.py
+++ b/src/api/store/technology.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.context import Context
 from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergizeAPIError
 from api.store.utils import get_user_from_context
@@ -25,7 +25,7 @@ class TechnologyStore:
             return technology, None
 
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_technologies(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -37,7 +37,7 @@ class TechnologyStore:
             technologies = Technology.objects.filter(Q(campaign_account_id=campaign_account_id)|Q(user__id=context.user_id), is_deleted=False)
             return technologies.distinct(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_technology(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -55,7 +55,7 @@ class TechnologyStore:
             technology.save()
             return technology, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_technology(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -79,7 +79,7 @@ class TechnologyStore:
             technology.save()
             return technology, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_technology(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -96,7 +96,7 @@ class TechnologyStore:
             technology.update(is_deleted=True)
             return technology.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_technologies_for_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -104,7 +104,7 @@ class TechnologyStore:
             technologies = Technology.objects.filter(is_deleted=False)
             return technologies, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_technology_coach(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -129,7 +129,7 @@ class TechnologyStore:
 
             return coach, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def remove_technology_coach(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -147,7 +147,7 @@ class TechnologyStore:
 
             return coach.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_technology_vendor(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -173,7 +173,7 @@ class TechnologyStore:
 
             return created_list, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -198,7 +198,7 @@ class TechnologyStore:
         
             return tech_vendor, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -209,7 +209,7 @@ class TechnologyStore:
             vendors = TechnologyVendor.objects.filter(technology__id=tech, is_deleted=False)
             return vendors, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_technology_coaches(self, context: Context, args) -> Tuple[TechnologyCoach, MassEnergizeAPIError]:
@@ -218,7 +218,7 @@ class TechnologyStore:
             coaches = TechnologyCoach.objects.filter(technology__id=tech, is_deleted=False)
             return coaches, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def list_technology_overviews(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -227,7 +227,7 @@ class TechnologyStore:
             overviews = TechnologyOverview.objects.filter(technology__id=tech, is_deleted=False)
             return overviews, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def add_technology_overview(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -253,7 +253,7 @@ class TechnologyStore:
         
             return tech_overview, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_technology_overview(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -276,7 +276,7 @@ class TechnologyStore:
 
             return tech_overview.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_technology_overview(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -294,7 +294,7 @@ class TechnologyStore:
 
             return tech_overview, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_technology_coach(self, context: Context, args) -> Tuple[TechnologyCoach, MassEnergizeAPIError]:
@@ -316,7 +316,7 @@ class TechnologyStore:
 
             return coach.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def create_technology_deal(self, context: Context, args) -> Tuple[TechnologyDeal, MassEnergizeAPIError]:
@@ -332,7 +332,7 @@ class TechnologyStore:
 
             return technology_deal, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def update_technology_deal(self, context: Context, args) -> Tuple[TechnologyDeal, MassEnergizeAPIError]:
@@ -347,7 +347,7 @@ class TechnologyStore:
 
             return technology_deal.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
 
     def delete_technology_deal(self, context: Context, args) -> Tuple[TechnologyDeal, MassEnergizeAPIError]:
@@ -362,7 +362,7 @@ class TechnologyStore:
 
             return technology_deal, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -390,7 +390,7 @@ class TechnologyStore:
 
             return technology_vendor, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -423,7 +423,7 @@ class TechnologyStore:
 
             return technology_vendor, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
 
@@ -445,7 +445,7 @@ class TechnologyStore:
 
             return technology_action, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
     
     def update_technology_action(self, context: Context, args) -> Tuple[TechnologyAction, MassEnergizeAPIError]:
@@ -464,7 +464,7 @@ class TechnologyStore:
 
             return technology_action.first(), None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)
         
     
@@ -480,5 +480,5 @@ class TechnologyStore:
 
             return technology_action, None
         except Exception as e:
-            logger.error(message=str(e), exception=e)
+            log.exception(e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/technology.py
+++ b/src/api/store/technology.py
@@ -1,5 +1,5 @@
 from typing import Tuple
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.context import Context
 from _main_.utils.massenergize_errors import CustomMassenergizeError, MassEnergizeAPIError
 from api.store.utils import get_user_from_context
@@ -25,7 +25,7 @@ class TechnologyStore:
             return technology, None
 
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_technologies(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -37,7 +37,7 @@ class TechnologyStore:
             technologies = Technology.objects.filter(Q(campaign_account_id=campaign_account_id)|Q(user__id=context.user_id), is_deleted=False)
             return technologies.distinct(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_technology(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -55,7 +55,7 @@ class TechnologyStore:
             technology.save()
             return technology, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_technology(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -79,7 +79,7 @@ class TechnologyStore:
             technology.save()
             return technology, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_technology(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -96,7 +96,7 @@ class TechnologyStore:
             technology.update(is_deleted=True)
             return technology.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_technologies_for_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -104,7 +104,7 @@ class TechnologyStore:
             technologies = Technology.objects.filter(is_deleted=False)
             return technologies, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_technology_coach(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -129,7 +129,7 @@ class TechnologyStore:
 
             return coach, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def remove_technology_coach(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -147,7 +147,7 @@ class TechnologyStore:
 
             return coach.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_technology_vendor(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -173,7 +173,7 @@ class TechnologyStore:
 
             return created_list, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -198,7 +198,7 @@ class TechnologyStore:
         
             return tech_vendor, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -209,7 +209,7 @@ class TechnologyStore:
             vendors = TechnologyVendor.objects.filter(technology__id=tech, is_deleted=False)
             return vendors, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_technology_coaches(self, context: Context, args) -> Tuple[TechnologyCoach, MassEnergizeAPIError]:
@@ -218,7 +218,7 @@ class TechnologyStore:
             coaches = TechnologyCoach.objects.filter(technology__id=tech, is_deleted=False)
             return coaches, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def list_technology_overviews(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -227,7 +227,7 @@ class TechnologyStore:
             overviews = TechnologyOverview.objects.filter(technology__id=tech, is_deleted=False)
             return overviews, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def add_technology_overview(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -253,7 +253,7 @@ class TechnologyStore:
         
             return tech_overview, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_technology_overview(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -276,7 +276,7 @@ class TechnologyStore:
 
             return tech_overview.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_technology_overview(self, context: Context, args) -> Tuple[TechnologyOverview, MassEnergizeAPIError]:
@@ -294,7 +294,7 @@ class TechnologyStore:
 
             return tech_overview, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_technology_coach(self, context: Context, args) -> Tuple[TechnologyCoach, MassEnergizeAPIError]:
@@ -316,7 +316,7 @@ class TechnologyStore:
 
             return coach.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def create_technology_deal(self, context: Context, args) -> Tuple[TechnologyDeal, MassEnergizeAPIError]:
@@ -332,7 +332,7 @@ class TechnologyStore:
 
             return technology_deal, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def update_technology_deal(self, context: Context, args) -> Tuple[TechnologyDeal, MassEnergizeAPIError]:
@@ -347,7 +347,7 @@ class TechnologyStore:
 
             return technology_deal.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
 
     def delete_technology_deal(self, context: Context, args) -> Tuple[TechnologyDeal, MassEnergizeAPIError]:
@@ -362,7 +362,7 @@ class TechnologyStore:
 
             return technology_deal, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -390,7 +390,7 @@ class TechnologyStore:
 
             return technology_vendor, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -423,7 +423,7 @@ class TechnologyStore:
 
             return technology_vendor, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
 
@@ -445,7 +445,7 @@ class TechnologyStore:
 
             return technology_action, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
     
     def update_technology_action(self, context: Context, args) -> Tuple[TechnologyAction, MassEnergizeAPIError]:
@@ -464,7 +464,7 @@ class TechnologyStore:
 
             return technology_action.first(), None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)
         
     
@@ -480,5 +480,5 @@ class TechnologyStore:
 
             return technology_action, None
         except Exception as e:
-            capture_message(str(e), level="error")
+            logger.error(message=str(e), exception=e)
             return None, CustomMassenergizeError(e)

--- a/src/api/store/testimonial.py
+++ b/src/api/store/testimonial.py
@@ -10,7 +10,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.context import Context
 from .utils import get_community, get_user, unique_media_filename
 from django.db.models import Q
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 class TestimonialStore:
@@ -24,7 +24,7 @@ class TestimonialStore:
         return None, InvalidResourceError()
       return testimonial, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
       
   def list_testimonials(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -64,7 +64,7 @@ class TestimonialStore:
 
       return  testimonials, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def create_testimonial(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -143,7 +143,7 @@ class TestimonialStore:
 
       return new_testimonial, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def update_testimonial(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -256,7 +256,7 @@ class TestimonialStore:
         # ---------------------------------------------------------------- 
       return testimonial, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def rank_testimonial(self, args,context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -281,7 +281,7 @@ class TestimonialStore:
       else:
         raise Exception("Testimonial ID not provided to testimonials.rank")
     except Exception as e:
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return None, CustomMassenergizeError(e)
 
   def delete_testimonial(self, context: Context, testimonial_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -298,7 +298,7 @@ class TestimonialStore:
       # ----------------------------------------------------------------
       return testimonial, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_testimonials_for_community_admin(self,  context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -330,7 +330,7 @@ class TestimonialStore:
       testimonials = Testimonial.objects.filter(community__id=community_id, is_deleted=False,*filter_params).select_related('image', 'community').prefetch_related('tags')
       return testimonials.distinct(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def list_testimonials_for_super_admin(self, context: Context,args):
@@ -349,5 +349,5 @@ class TestimonialStore:
       return testimonials.distinct(), None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/testimonial.py
+++ b/src/api/store/testimonial.py
@@ -10,7 +10,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.context import Context
 from .utils import get_community, get_user, unique_media_filename
 from django.db.models import Q
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 class TestimonialStore:
@@ -24,7 +24,7 @@ class TestimonialStore:
         return None, InvalidResourceError()
       return testimonial, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
       
   def list_testimonials(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -64,7 +64,7 @@ class TestimonialStore:
 
       return  testimonials, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def create_testimonial(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -143,7 +143,7 @@ class TestimonialStore:
 
       return new_testimonial, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def update_testimonial(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -256,7 +256,7 @@ class TestimonialStore:
         # ---------------------------------------------------------------- 
       return testimonial, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def rank_testimonial(self, args,context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -281,7 +281,7 @@ class TestimonialStore:
       else:
         raise Exception("Testimonial ID not provided to testimonials.rank")
     except Exception as e:
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return None, CustomMassenergizeError(e)
 
   def delete_testimonial(self, context: Context, testimonial_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -298,7 +298,7 @@ class TestimonialStore:
       # ----------------------------------------------------------------
       return testimonial, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_testimonials_for_community_admin(self,  context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -330,7 +330,7 @@ class TestimonialStore:
       testimonials = Testimonial.objects.filter(community__id=community_id, is_deleted=False,*filter_params).select_related('image', 'community').prefetch_related('tags')
       return testimonials.distinct(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def list_testimonials_for_super_admin(self, context: Context,args):
@@ -349,5 +349,5 @@ class TestimonialStore:
       return testimonials.distinct(), None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -12,7 +12,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
 from _main_.settings import DEBUG, IS_PROD, IS_CANARY
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from .utils import get_community, get_user_from_context, get_user_or_die, get_community_or_die, get_admin_communities, remove_dups, \
   find_reu_community, split_location_string, check_location
 import json
@@ -309,7 +309,7 @@ class UserStore:
         return self.decline_mou( user, args), None
       
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -383,7 +383,7 @@ class UserStore:
     except Exception as e:
       if IS_PROD or IS_CANARY:
         send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": str(e)+str(context)}) 
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       import traceback
       traceback.print_exc()
       return None, CustomMassenergizeError(e)
@@ -401,7 +401,7 @@ class UserStore:
       return user, None
     
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def remove_household(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -419,7 +419,7 @@ class UserStore:
       return RealEstateUnit.objects.get(pk=household_id).delete(), None
     
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def add_household(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -444,7 +444,7 @@ class UserStore:
     
     except Exception as e:
       print("=== error from add_household ===", e)
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def edit_household(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -474,7 +474,7 @@ class UserStore:
       reu.save()
       return reu, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def list_households(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -483,7 +483,7 @@ class UserStore:
       
       return user.real_estate_units.all(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def list_users(self, context,community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -536,7 +536,7 @@ class UserStore:
       attendees = EventAttendee.objects.filter(user=user)
       return attendees, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def check_user_imported(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -551,7 +551,7 @@ class UserStore:
         return {"imported": True, "firstName": first_name, "lastName": last_name, "preferredName": first_name}, None
       return {"imported": False}, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def complete_imported_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -562,7 +562,7 @@ class UserStore:
         return MassenergizeResponse(data={"completed": False}), None
       return MassenergizeResponse(data={"completed": True}), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def create_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -689,7 +689,7 @@ class UserStore:
       return res, None
     
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def update_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -735,7 +735,7 @@ class UserStore:
         return None, CustomMassenergizeError('permission_denied')
     
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def delete_user(self, context: Context, user_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -816,7 +816,7 @@ class UserStore:
 
       return users.first(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def list_users_for_community_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -860,7 +860,7 @@ class UserStore:
       users = UserProfile.objects.filter(id__in={user.id for user in users}).filter(*filter_params)
       return users.distinct(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def list_users_for_super_admin(self, context: Context, args):
@@ -890,7 +890,7 @@ class UserStore:
       users = UserProfile.objects.filter(is_deleted=False, *filter_params)
       return users.distinct(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def add_action_todo(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -915,7 +915,7 @@ class UserStore:
       
       return todo, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def list_completed_actions(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -934,7 +934,7 @@ class UserStore:
       
       return todo, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def remove_user_action(self, context: Context, user_action_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -964,7 +964,7 @@ class UserStore:
     except Exception as e:
       if IS_PROD or IS_CANARY:
         send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": str(e)+str(context)}) 
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
   
   def add_invited_user(self, context: Context, args, first_name, last_name, email) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1043,7 +1043,7 @@ class UserStore:
 
       return ret, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
     
   
@@ -1080,7 +1080,7 @@ class UserStore:
       return follow, None
     
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
     
   def get_loosed_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1101,6 +1101,6 @@ class UserStore:
       return user, None
     
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -12,7 +12,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, InvalidResour
 from _main_.utils.massenergize_response import MassenergizeResponse
 from _main_.utils.context import Context
 from _main_.settings import DEBUG, IS_PROD, IS_CANARY
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from .utils import get_community, get_user_from_context, get_user_or_die, get_community_or_die, get_admin_communities, remove_dups, \
   find_reu_community, split_location_string, check_location
 import json
@@ -309,7 +309,7 @@ class UserStore:
         return self.decline_mou( user, args), None
       
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -383,7 +383,7 @@ class UserStore:
     except Exception as e:
       if IS_PROD or IS_CANARY:
         send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": str(e)+str(context)}) 
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       import traceback
       traceback.print_exc()
       return None, CustomMassenergizeError(e)
@@ -401,7 +401,7 @@ class UserStore:
       return user, None
     
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def remove_household(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -419,7 +419,7 @@ class UserStore:
       return RealEstateUnit.objects.get(pk=household_id).delete(), None
     
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def add_household(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -444,7 +444,7 @@ class UserStore:
     
     except Exception as e:
       print("=== error from add_household ===", e)
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def edit_household(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -474,7 +474,7 @@ class UserStore:
       reu.save()
       return reu, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def list_households(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -483,7 +483,7 @@ class UserStore:
       
       return user.real_estate_units.all(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def list_users(self, context,community_id) -> Tuple[list, MassEnergizeAPIError]:
@@ -536,7 +536,7 @@ class UserStore:
       attendees = EventAttendee.objects.filter(user=user)
       return attendees, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def check_user_imported(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -551,7 +551,7 @@ class UserStore:
         return {"imported": True, "firstName": first_name, "lastName": last_name, "preferredName": first_name}, None
       return {"imported": False}, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def complete_imported_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -562,7 +562,7 @@ class UserStore:
         return MassenergizeResponse(data={"completed": False}), None
       return MassenergizeResponse(data={"completed": True}), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def create_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -689,7 +689,7 @@ class UserStore:
       return res, None
     
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def update_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -735,7 +735,7 @@ class UserStore:
         return None, CustomMassenergizeError('permission_denied')
     
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def delete_user(self, context: Context, user_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -816,7 +816,7 @@ class UserStore:
 
       return users.first(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def list_users_for_community_admin(self, context: Context, args) -> Tuple[list, MassEnergizeAPIError]:
@@ -860,7 +860,7 @@ class UserStore:
       users = UserProfile.objects.filter(id__in={user.id for user in users}).filter(*filter_params)
       return users.distinct(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def list_users_for_super_admin(self, context: Context, args):
@@ -890,7 +890,7 @@ class UserStore:
       users = UserProfile.objects.filter(is_deleted=False, *filter_params)
       return users.distinct(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def add_action_todo(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -915,7 +915,7 @@ class UserStore:
       
       return todo, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def list_completed_actions(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -934,7 +934,7 @@ class UserStore:
       
       return todo, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def remove_user_action(self, context: Context, user_action_id) -> Tuple[dict, MassEnergizeAPIError]:
@@ -964,7 +964,7 @@ class UserStore:
     except Exception as e:
       if IS_PROD or IS_CANARY:
         send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": str(e)+str(context)}) 
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
   
   def add_invited_user(self, context: Context, args, first_name, last_name, email) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1043,7 +1043,7 @@ class UserStore:
 
       return ret, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
     
   
@@ -1080,7 +1080,7 @@ class UserStore:
       return follow, None
     
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
     
   def get_loosed_user(self, context: Context, args) -> Tuple[dict, MassEnergizeAPIError]:
@@ -1101,6 +1101,6 @@ class UserStore:
       return user, None
     
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 

--- a/src/api/store/utils.py
+++ b/src/api/store/utils.py
@@ -10,7 +10,7 @@ from database.utils.constants import SHORT_STR_LEN
 import zipcodes
 import datetime
 from carbon_calculator.carbonCalculator import AverageImpact
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 
 def getCarbonScoreFromActionRel(actionRel): 
@@ -28,7 +28,7 @@ def get_community(community_id=None, subdomain=None):
     elif subdomain: 
       return Community.objects.filter(subdomain=subdomain).first(), None
   except Exception as e:
-    logger.error(message=str(e), exception=e)
+    log.exception(e)
     return None, CustomMassenergizeError(e)
 
   return None, CustomMassenergizeError("Missing community_id or subdomain field")
@@ -41,7 +41,7 @@ def get_user(user_id, email=None):
       return UserProfile.objects.filter(pk=user_id).first(), None
     return None, CustomMassenergizeError("Missing user_id or email field")
   except Exception as e:
-    logger.error(message=str(e), exception=e)
+    log.exception(e)
     return None, CustomMassenergizeError(e)
 
 @timed

--- a/src/api/store/utils.py
+++ b/src/api/store/utils.py
@@ -10,7 +10,7 @@ from database.utils.constants import SHORT_STR_LEN
 import zipcodes
 import datetime
 from carbon_calculator.carbonCalculator import AverageImpact
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 
 def getCarbonScoreFromActionRel(actionRel): 
@@ -28,7 +28,7 @@ def get_community(community_id=None, subdomain=None):
     elif subdomain: 
       return Community.objects.filter(subdomain=subdomain).first(), None
   except Exception as e:
-    capture_message(str(e), level="error")
+    logger.error(message=str(e), exception=e)
     return None, CustomMassenergizeError(e)
 
   return None, CustomMassenergizeError("Missing community_id or subdomain field")
@@ -41,7 +41,7 @@ def get_user(user_id, email=None):
       return UserProfile.objects.filter(pk=user_id).first(), None
     return None, CustomMassenergizeError("Missing user_id or email field")
   except Exception as e:
-    capture_message(str(e), level="error")
+    logger.error(message=str(e), exception=e)
     return None, CustomMassenergizeError(e)
 
 @timed

--- a/src/api/store/vendor.py
+++ b/src/api/store/vendor.py
@@ -8,7 +8,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, NotAuthorized
 from _main_.utils.context import Context
 from .utils import get_community_or_die, get_admin_communities, get_new_title
 from _main_.utils.context import Context
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 from django.db.models import Q
 
@@ -30,7 +30,7 @@ class VendorStore:
 
       return vendor, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -59,7 +59,7 @@ class VendorStore:
 
       return vendors, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def create_vendor(self, context: Context, args, user_submitted) -> Tuple[Vendor, MassEnergizeAPIError]:
@@ -133,7 +133,7 @@ class VendorStore:
     # ---------------------------------------------------------------- 
       return new_vendor, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def update_vendor(self, context: Context, args, user_submitted) -> Tuple[dict, MassEnergizeAPIError]:
@@ -238,7 +238,7 @@ class VendorStore:
       return vendor, None
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
   def rank_vendor(self, args, context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -257,7 +257,7 @@ class VendorStore:
       else:
         raise Exception("Rank and ID not provided to vendors.rank")
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -272,7 +272,7 @@ class VendorStore:
       # ----------------------------------------------------------------
       return vendor, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -330,7 +330,7 @@ class VendorStore:
       # ----------------------------------------------------------------
       return new_vendor, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -376,7 +376,7 @@ class VendorStore:
         vendors = vendors.exclude(more_info__icontains='"created_via_campaign": true').distinct()
       return vendors, None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)
 
 
@@ -387,5 +387,5 @@ class VendorStore:
       vendors = Vendor.objects.filter(is_deleted=False, *filter_params).select_related('logo').prefetch_related('communities', 'tags')
       return vendors.exclude(more_info__icontains='"created_via_campaign": true').distinct(), None
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError(e)

--- a/src/api/store/vendor.py
+++ b/src/api/store/vendor.py
@@ -8,7 +8,7 @@ from _main_.utils.massenergize_errors import MassEnergizeAPIError, NotAuthorized
 from _main_.utils.context import Context
 from .utils import get_community_or_die, get_admin_communities, get_new_title
 from _main_.utils.context import Context
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 from django.db.models import Q
 
@@ -30,7 +30,7 @@ class VendorStore:
 
       return vendor, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -59,7 +59,7 @@ class VendorStore:
 
       return vendors, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def create_vendor(self, context: Context, args, user_submitted) -> Tuple[Vendor, MassEnergizeAPIError]:
@@ -133,7 +133,7 @@ class VendorStore:
     # ---------------------------------------------------------------- 
       return new_vendor, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def update_vendor(self, context: Context, args, user_submitted) -> Tuple[dict, MassEnergizeAPIError]:
@@ -238,7 +238,7 @@ class VendorStore:
       return vendor, None
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
   def rank_vendor(self, args, context) -> Tuple[dict, MassEnergizeAPIError]:
@@ -257,7 +257,7 @@ class VendorStore:
       else:
         raise Exception("Rank and ID not provided to vendors.rank")
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -272,7 +272,7 @@ class VendorStore:
       # ----------------------------------------------------------------
       return vendor, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -330,7 +330,7 @@ class VendorStore:
       # ----------------------------------------------------------------
       return new_vendor, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -376,7 +376,7 @@ class VendorStore:
         vendors = vendors.exclude(more_info__icontains='"created_via_campaign": true').distinct()
       return vendors, None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)
 
 
@@ -387,5 +387,5 @@ class VendorStore:
       vendors = Vendor.objects.filter(is_deleted=False, *filter_params).select_related('logo').prefetch_related('communities', 'tags')
       return vendors.exclude(more_info__icontains='"created_via_campaign": true').distinct(), None
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError(e)

--- a/src/api/tests/integration/test_download.py
+++ b/src/api/tests/integration/test_download.py
@@ -94,21 +94,21 @@ class DownloadTestCase(TestCase):
     # first try for no user signed in
     signinAs(self.client, None)
     response = self.client.post('/api/downloads.users', urlencode({"team_id": self.TEAM1.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     response = response.toDict()
     self.assertFalse(response["success"])
 
     # next try for regular user signed in
     signinAs(self.client, self.USER)
     response = self.client.post('/api/downloads.users', urlencode({"team_id": self.TEAM1.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     response = response.toDict()
     self.assertFalse(response["success"])
 
     # next try for cadmin signed in
     signinAs(self.client, self.CADMIN)
     response = self.client.post('/api/downloads.users', urlencode({"team_id": self.TEAM1.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     self.assertTrue(response.toDict().get("success"))
 
 
@@ -147,41 +147,41 @@ class DownloadTestCase(TestCase):
     # first try for no user signed in
     signinAs(self.client, None)
     response = self.client.post('/api/downloads.actions', urlencode({"community_id": self.COMMUNITY.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     response = response.toDict()
     self.assertFalse(response["success"])
 
     # next try for regular user signed in
     signinAs(self.client, self.USER)
     response = self.client.post('/api/downloads.actions', urlencode({"community_id": self.COMMUNITY.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     response = response.toDict()
     self.assertFalse(response["success"])
 
     # next try for cadmin signed in
     signinAs(self.client, self.CADMIN)
     response = self.client.post('/api/downloads.actions', urlencode({"community_id": self.COMMUNITY.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     self.assertTrue(response.toDict()["success"])
 
     # next try for sadmin signed in
     signinAs(self.client, self.SADMIN)
     response = self.client.post('/api/downloads.actions', urlencode({"community_id": self.COMMUNITY.id}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     self.assertTrue(response.toDict()["success"])
 
     # don't specify community or team, cadmin signed in
     # now this will work, but "community" will be first column
     signinAs(self.client, self.CADMIN)
     response = self.client.post('/api/downloads.actions', urlencode({}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     self.assertTrue(response.toDict().get("success"))
 
 
     # don't specify community or team, sadmin signed in
     signinAs(self.client, self.SADMIN)
     response = self.client.post('/api/downloads.actions', urlencode({}), content_type="application/x-www-form-urlencoded")
-    self.assertEquals(type(response), MassenergizeResponse)
+    self.assertTrue(isinstance(response, MassenergizeResponse))
     self.assertTrue(response.toDict().get("success"))
 
 

--- a/src/authentication/middleware.py
+++ b/src/authentication/middleware.py
@@ -7,7 +7,7 @@ from _main_.utils.context import Context
 from _main_.settings import SECRET_KEY, RUN_SERVER_LOCALLY
 from firebase_admin import auth
 import jwt
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from typing import Tuple
 
 from _main_.utils.utils import Console
@@ -40,7 +40,7 @@ class MassenergizeJWTAuthMiddleware:
     except jwt.InvalidTokenError:
       return None, CustomMassenergizeError('invalid_token')
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return None, CustomMassenergizeError('invalid_token')
 
 
@@ -91,7 +91,7 @@ class MassenergizeJWTAuthMiddleware:
       request.context = ctx
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return CustomMassenergizeError(e)
 
 

--- a/src/authentication/middleware.py
+++ b/src/authentication/middleware.py
@@ -7,7 +7,7 @@ from _main_.utils.context import Context
 from _main_.settings import SECRET_KEY, RUN_SERVER_LOCALLY
 from firebase_admin import auth
 import jwt
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from typing import Tuple
 
 from _main_.utils.utils import Console
@@ -40,7 +40,7 @@ class MassenergizeJWTAuthMiddleware:
     except jwt.InvalidTokenError:
       return None, CustomMassenergizeError('invalid_token')
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return None, CustomMassenergizeError('invalid_token')
 
 
@@ -91,7 +91,7 @@ class MassenergizeJWTAuthMiddleware:
       request.context = ctx
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return CustomMassenergizeError(e)
 
 

--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -9,7 +9,7 @@ from _main_.utils.common import get_request_contents
 from database.models import UserProfile
 from _main_.settings import SECRET_KEY
 import json, jwt
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 def login(request):
   # This does the same work as verify
@@ -44,7 +44,7 @@ def who_am_i(request):
     return MassenergizeResponse(user.full_json())
 
   except Exception as e:
-    capture_message(str(e), level="error")
+    logger.error(message=str(e), exception=e)
     return CustomMassenergizeError(e)
 
 
@@ -78,5 +78,5 @@ def verify(request):
       return CustomMassenergizeError("Invalid Auth")
 
   except Exception as e:
-    capture_message(str(e), level="error")
+    logger.error(message=str(e), exception=e)
     return CustomMassenergizeError(e)

--- a/src/authentication/views.py
+++ b/src/authentication/views.py
@@ -9,7 +9,7 @@ from _main_.utils.common import get_request_contents
 from database.models import UserProfile
 from _main_.settings import SECRET_KEY
 import json, jwt
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 def login(request):
   # This does the same work as verify
@@ -44,7 +44,7 @@ def who_am_i(request):
     return MassenergizeResponse(user.full_json())
 
   except Exception as e:
-    logger.error(message=str(e), exception=e)
+    log.exception(e)
     return CustomMassenergizeError(e)
 
 
@@ -78,5 +78,5 @@ def verify(request):
       return CustomMassenergizeError("Invalid Auth")
 
   except Exception as e:
-    logger.error(message=str(e), exception=e)
+    log.exception(e)
     return CustomMassenergizeError(e)

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -665,7 +665,7 @@ class Community(models.Model):
         if impact_page_settings:
             display_prefs = impact_page_settings.more_info or {}
         else:
-            # capture_message("Impact Page Settings not found", level="error")
+            # logger.error("Impact Page Settings not found", level="error")
             display_prefs = {}  # not usual - show nothing
 
         value = 0

--- a/src/database/models.py
+++ b/src/database/models.py
@@ -665,7 +665,7 @@ class Community(models.Model):
         if impact_page_settings:
             display_prefs = impact_page_settings.more_info or {}
         else:
-            # logger.error("Impact Page Settings not found", level="error")
+            # log.error("Impact Page Settings not found", level="error")
             display_prefs = {}  # not usual - show nothing
 
         value = 0

--- a/src/database/utils/common.py
+++ b/src/database/utils/common.py
@@ -10,7 +10,7 @@ from django.core import serializers
 from django.forms.models import model_to_dict
 from collections.abc import Iterable
 from _main_.settings import AWS_S3_REGION_NAME, AWS_STORAGE_BUCKET_NAME
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 from _main_.utils.utils import Console
 import boto3
@@ -38,7 +38,7 @@ def json_loader(file) -> dict:
       data = my_file.read()
     return json.loads(data)
   except Exception as e:
-    capture_message(str(e), level="error")
+    logger.error(message=str(e), exception=e)
     
     return error_msg("The JSON file you specified does not exist")
 
@@ -126,7 +126,7 @@ def get_summary_info(obj) -> dict:
       return obj.info()
     return None
   except Exception as e:
-    capture_message(str(e), level="error")
+    logger.error(message=str(e), exception=e)
     
     return {'id': obj.pk}
 
@@ -164,7 +164,7 @@ def get_request_contents(request):
     try:
       return json.loads(request.body.decode('utf-8'))
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return {}
 
 

--- a/src/database/utils/common.py
+++ b/src/database/utils/common.py
@@ -10,7 +10,7 @@ from django.core import serializers
 from django.forms.models import model_to_dict
 from collections.abc import Iterable
 from _main_.settings import AWS_S3_REGION_NAME, AWS_STORAGE_BUCKET_NAME
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 from _main_.utils.utils import Console
 import boto3
@@ -38,7 +38,7 @@ def json_loader(file) -> dict:
       data = my_file.read()
     return json.loads(data)
   except Exception as e:
-    logger.error(message=str(e), exception=e)
+    log.exception(e)
     
     return error_msg("The JSON file you specified does not exist")
 
@@ -126,7 +126,7 @@ def get_summary_info(obj) -> dict:
       return obj.info()
     return None
   except Exception as e:
-    logger.error(message=str(e), exception=e)
+    log.exception(e)
     
     return {'id': obj.pk}
 
@@ -164,7 +164,7 @@ def get_request_contents(request):
     try:
       return json.loads(request.body.decode('utf-8'))
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return {}
 
 

--- a/src/database/utils/create_factory.py
+++ b/src/database/utils/create_factory.py
@@ -7,7 +7,7 @@ from _main_.utils.utils import get_models_and_field_types
 from database import models
 from _main_.utils.constants import CREATE_ERROR_MSG
 from collections.abc import Iterable
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 MODELS_AND_FIELDS = get_models_and_field_types(models)
 
@@ -63,7 +63,7 @@ class CreateFactory:
       new_object.save()
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       errors =  [CREATE_ERROR_MSG, str(e)]
     return new_object, errors
 
@@ -103,7 +103,7 @@ class CreateFactory:
      
 
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       obj, errors =  None, [CREATE_ERROR_MSG, str(e)]
       
     return obj, errors

--- a/src/database/utils/create_factory.py
+++ b/src/database/utils/create_factory.py
@@ -7,7 +7,7 @@ from _main_.utils.utils import get_models_and_field_types
 from database import models
 from _main_.utils.constants import CREATE_ERROR_MSG
 from collections.abc import Iterable
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 MODELS_AND_FIELDS = get_models_and_field_types(models)
 
@@ -63,7 +63,7 @@ class CreateFactory:
       new_object.save()
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       errors =  [CREATE_ERROR_MSG, str(e)]
     return new_object, errors
 
@@ -103,7 +103,7 @@ class CreateFactory:
      
 
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       obj, errors =  None, [CREATE_ERROR_MSG, str(e)]
       
     return obj, errors

--- a/src/database/utils/database_reader.py
+++ b/src/database/utils/database_reader.py
@@ -5,7 +5,7 @@ This is a factory dedicated to reading objects in the Massenergize Database
 from _main_.utils.constants import READ_ERROR_MSG
 from _main_.utils.utils import get_models_and_field_types
 from database import models
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 MODELS_AND_FIELDS = get_models_and_field_types(models)
 
@@ -45,7 +45,7 @@ class DatabaseReader:
         return (data, errors)
       return [], errors
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       return  None, [READ_ERROR_MSG, str(e)]
     
 

--- a/src/database/utils/database_reader.py
+++ b/src/database/utils/database_reader.py
@@ -5,7 +5,7 @@ This is a factory dedicated to reading objects in the Massenergize Database
 from _main_.utils.constants import READ_ERROR_MSG
 from _main_.utils.utils import get_models_and_field_types
 from database import models
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 MODELS_AND_FIELDS = get_models_and_field_types(models)
 
@@ -45,7 +45,7 @@ class DatabaseReader:
         return (data, errors)
       return [], errors
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       return  None, [READ_ERROR_MSG, str(e)]
     
 

--- a/src/database/utils/json_response_wrapper.py
+++ b/src/database/utils/json_response_wrapper.py
@@ -7,7 +7,7 @@ errors to the caller of a particular route
 from django.http import JsonResponse
 # from .common import convert_to_json
 from collections.abc import Iterable
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 class Json(JsonResponse):
   def __init__(self, raw_data=None, errors=None, use_full_json=False, do_not_serialize=False):    
@@ -31,7 +31,7 @@ class Json(JsonResponse):
       else:
         cleaned_data['data'] =  data.full_json()
     except Exception as e:
-      logger.error(message=str(e), exception=e)
+      log.exception(e)
       cleaned_data['errors'] = [e]
     return cleaned_data
 

--- a/src/database/utils/json_response_wrapper.py
+++ b/src/database/utils/json_response_wrapper.py
@@ -7,7 +7,7 @@ errors to the caller of a particular route
 from django.http import JsonResponse
 # from .common import convert_to_json
 from collections.abc import Iterable
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 
 class Json(JsonResponse):
   def __init__(self, raw_data=None, errors=None, use_full_json=False, do_not_serialize=False):    
@@ -31,7 +31,7 @@ class Json(JsonResponse):
       else:
         cleaned_data['data'] =  data.full_json()
     except Exception as e:
-      capture_message(str(e), level="error")
+      logger.error(message=str(e), exception=e)
       cleaned_data['errors'] = [e]
     return cleaned_data
 

--- a/src/task_queue/database_tasks/contents_spacing_correction.py
+++ b/src/task_queue/database_tasks/contents_spacing_correction.py
@@ -1,7 +1,7 @@
 import csv
 import datetime
 from django.apps import apps
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 #from _main_.utils.feature_flag_keys import UPDATE_HTML_CONTENT_FORMAT_FF
 from api.utils.constants import DATA_DOWNLOAD_TEMPLATE
@@ -107,7 +107,7 @@ def process_spacing_data(task=None):
         return True
     except Exception as e:
         print(str(e))
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return False
   
     

--- a/src/task_queue/database_tasks/contents_spacing_correction.py
+++ b/src/task_queue/database_tasks/contents_spacing_correction.py
@@ -1,7 +1,7 @@
 import csv
 import datetime
 from django.apps import apps
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 #from _main_.utils.feature_flag_keys import UPDATE_HTML_CONTENT_FORMAT_FF
 from api.utils.constants import DATA_DOWNLOAD_TEMPLATE
@@ -107,7 +107,7 @@ def process_spacing_data(task=None):
         return True
     except Exception as e:
         print(str(e))
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return False
   
     

--- a/src/task_queue/database_tasks/update_actions_content.py
+++ b/src/task_queue/database_tasks/update_actions_content.py
@@ -1,7 +1,7 @@
 import csv
 import datetime
 from django.apps import apps
-from sentry_sdk import capture_message
+from _main_.utils.massenergize_logger import logger
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 from _main_.utils.feature_flag_keys import UPDATE_ACTIONS_CONTENT_FF
 from api.utils.constants import DATA_DOWNLOAD_TEMPLATE
@@ -123,7 +123,7 @@ def update_actions_content(task=None):
         return True
     except Exception as e:
         print(str(e))
-        capture_message(str(e), level="error")
+        logger.error(message=str(e), exception=e)
         return False
   
     

--- a/src/task_queue/database_tasks/update_actions_content.py
+++ b/src/task_queue/database_tasks/update_actions_content.py
@@ -1,7 +1,7 @@
 import csv
 import datetime
 from django.apps import apps
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 from _main_.utils.feature_flag_keys import UPDATE_ACTIONS_CONTENT_FF
 from api.utils.constants import DATA_DOWNLOAD_TEMPLATE
@@ -123,7 +123,7 @@ def update_actions_content(task=None):
         return True
     except Exception as e:
         print(str(e))
-        logger.error(message=str(e), exception=e)
+        log.exception(e)
         return False
   
     

--- a/src/task_queue/tasks.py
+++ b/src/task_queue/tasks.py
@@ -9,9 +9,8 @@ from api.services.utils import send_slack_message
 from task_queue.helpers import is_time_to_run
 from .jobs import FUNCTIONS
 from .models import Task
+from _main_.utils.massenergize_logger import logger
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 FAILED = "FAILED"
 SUCCEEDED = "SUCCEEDED"

--- a/src/task_queue/tasks.py
+++ b/src/task_queue/tasks.py
@@ -9,7 +9,7 @@ from api.services.utils import send_slack_message
 from task_queue.helpers import is_time_to_run
 from .jobs import FUNCTIONS
 from .models import Task
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 
 FAILED = "FAILED"
@@ -24,11 +24,11 @@ def log_status(task, message):
 	task_name = get_task_info(task)
 
 	if task.status == FAILED:
-		logger.error(f"Task: {task_name}, Status: {task.status}, Info: {message}")
+		log.error(f"Task: {task_name}, Status: {task.status}, Info: {message}")
 		if IS_PROD:
 			send_slack_message(SLACK_SUPER_ADMINS_WEBHOOK_URL, {"text": f"Task: {task_name}, Status: {task.status}, Info: {message}"})
 	else:
-		logger.info(f"Task: {task_name}, Status: {task.status}, Info: {message}")
+		log.info(f"Task: {task_name}, Status: {task.status}, Info: {message}")
 
 
 @shared_task(bind=True, autoretry_for=(Exception,), retry_kwargs={'max_retries': 1, 'countdown': 5})
@@ -66,4 +66,4 @@ def run_some_task(self, task_id):
 			task.save()
 			
 	except Exception as e:
-		logger.error(f"Task: {task_id}, Status: ❌, Info: {str(e)}")
+		log.error(f"Task: {task_id}, Status: ❌, Info: {str(e)}")

--- a/src/website/views.py
+++ b/src/website/views.py
@@ -7,7 +7,7 @@ from _main_.utils.common import serialize_all
 from _main_.utils.massenergize_response import MassenergizeResponse
 from django.http import Http404, JsonResponse
 from _main_.settings import IS_PROD, IS_CANARY, RUN_SERVER_LOCALLY, EnvConfig
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 from api.decorators import x_frame_options_exempt
 from api.handlers.misc import MiscellaneousHandler
 from api.store.misc import MiscellaneousStore
@@ -32,7 +32,7 @@ from django.db.models import Q
 from django.template.loader import render_to_string
 from _main_.utils.metrics import timed
 import zipcodes
-from _main_.utils.massenergize_logger import logger
+from _main_.utils.massenergize_logger import log
 
 extract_text_from_html = html2text.HTML2Text()
 extract_text_from_html.ignore_links = True
@@ -957,7 +957,7 @@ def generate_sitemap_main(request):
 
 
 def handler400(request, exception):
-    logger.error(
+    log.error(
         exception=exception,
         args={
             'error_status_code': 400,
@@ -969,7 +969,7 @@ def handler400(request, exception):
 
 
 def handler403(request, exception):
-    logger.error(
+    log.error(
         exception=exception,
         extra={
             'error_status_code': 403,
@@ -981,7 +981,7 @@ def handler403(request, exception):
 
 
 def handler404(request, exception):
-    logger.error(
+    log.error(
         exception=exception,
         extra={
             'error_status_code': 404,
@@ -996,7 +996,7 @@ def handler404(request, exception):
 
 
 def handler500(request):
-    logger.error(
+    log.error(
         message=f"server_error",
         extra={
             'error_status_code': 500,


### PR DESCRIPTION
####  Summary / Highlights
Right now, most of the logs get sent to sentry but not cloud watch. In this PR, i centralize the lgoging functionality and add a few utilities to log exceptions.  
#### Details (Give details about what this PR accomplishes, include any screenshots etc)
Now, when we log, it will go to Cloudwatch and then also sentry.io

#### Testing Steps (Provide details on how your changes can be tested)
`make test`

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [x] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
