### PR TITLE
Refactor: Timezone Handling to Use ZoneInfo and Replace Deprecated datetime.datetime.utc()

### DIFF
--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -2,7 +2,7 @@ import io
 import json
 from querystring_parser import parser
 from _main_.utils.massenergize_errors import CustomMassenergizeError
-import pytz
+from zoneinfo import ZoneInfo
 from django.utils import timezone
 from datetime import datetime, timedelta
 from dateutil import tz
@@ -13,9 +13,13 @@ from openpyxl import Workbook
 from better_profanity import profanity
 
 
+def custom_timezone_info(zone="UTC"):
+    return ZoneInfo(zone)
+
+
 def get_date_and_time_in_milliseconds(**kwargs):
     hours = kwargs.get("hours", None)
-    date = datetime.now(tz=pytz.UTC)
+    date = datetime.now(tz=custom_timezone_info())
     if hours:
         delta = timedelta(hours=hours)
         date = date + delta
@@ -133,9 +137,9 @@ def parse_date(d):
         if d == "undefined" or d == "null":  # providing date as 'null' should clear it
             return None
         if len(d) == 10:
-            return pytz.utc.localize(datetime.strptime(d, "%Y-%m-%d"))
+            return datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=custom_timezone_info())
         else:
-            return pytz.utc.localize(datetime.strptime(d, "%Y-%m-%d %H:%M"))
+            return datetime.strptime(d, "%Y-%m-%d %H:%M").replace(tzinfo=custom_timezone_info())
 
     except Exception as e:
         capture_message(str(e), level="error")
@@ -290,7 +294,7 @@ def local_time():
 
 def utc_to_local(iso_str):
     local_zone = tz.tzlocal()
-    dt_utc = datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=pytz.UTC)
+    dt_utc = datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=custom_timezone_info())
     local_now = dt_utc.astimezone(local_zone)
     return local_now
 

--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -15,10 +15,34 @@ import datetime
 
 
 def custom_timezone_info(zone="UTC"):
+    if not zone:
+        zone = "UTC"
     return ZoneInfo(zone)
 
-def tz_aware_utc_now():
-    return datetime.datetime.now(datetime.timezone.utc)
+
+def parse_datetime_to_aware(datetime_str=None, timezone_str='UTC'):
+    """
+    :param datetime_str: The string representing the datetime to parse. If not provided, the current date and time will be used.
+    :param timezone_str: The string representing the timezone to apply to the parsed datetime. Defaults to 'UTC'.
+    :return: An aware datetime object.
+    
+    """
+    if not datetime_str:
+        datetime_str = datetime.datetime.now()
+    
+    if isinstance(datetime_str, datetime.datetime):
+        datetime_str = datetime_str.strftime('%Y-%m-%d %H:%M:%S')
+    try:
+        naive_datetime = datetime.datetime.strptime(datetime_str, '%Y-%m-%d %H:%M:%S.%f')
+    except ValueError:
+        naive_datetime = datetime.datetime.strptime(datetime_str, '%Y-%m-%d %H:%M:%S')
+    
+    try:
+        aware_datetime = timezone.make_aware(naive_datetime, custom_timezone_info(timezone_str))
+        return aware_datetime
+    except Exception as e:
+        log.exception(e)
+        return None
 
 
 def get_date_and_time_in_milliseconds(**kwargs):
@@ -291,7 +315,7 @@ def set_cookie(response, key, value):  # TODO
 
 def local_time():
     local_zone = tz.tzlocal()
-    dt_utc = tz_aware_utc_now()
+    dt_utc = parse_datetime_to_aware()
     local_now = dt_utc.astimezone(local_zone)
     return local_now
 

--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -4,22 +4,26 @@ from querystring_parser import parser
 from _main_.utils.massenergize_errors import CustomMassenergizeError
 from zoneinfo import ZoneInfo
 from django.utils import timezone
-from datetime import datetime, timedelta
+from datetime import timedelta
 from dateutil import tz
 from sentry_sdk import capture_message
 import base64
 import pyshorteners
 from openpyxl import Workbook
 from better_profanity import profanity
+import datetime
 
 
 def custom_timezone_info(zone="UTC"):
     return ZoneInfo(zone)
 
+def tz_aware_utc_now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
 
 def get_date_and_time_in_milliseconds(**kwargs):
     hours = kwargs.get("hours", None)
-    date = datetime.now(tz=custom_timezone_info())
+    date = datetime.datetime.now(tz=custom_timezone_info())
     if hours:
         delta = timedelta(hours=hours)
         date = date + delta
@@ -137,9 +141,9 @@ def parse_date(d):
         if d == "undefined" or d == "null":  # providing date as 'null' should clear it
             return None
         if len(d) == 10:
-            return datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=custom_timezone_info())
+            return datetime.datetime.strptime(d, "%Y-%m-%d").replace(tzinfo=custom_timezone_info())
         else:
-            return datetime.strptime(d, "%Y-%m-%d %H:%M").replace(tzinfo=custom_timezone_info())
+            return datetime.datetime.strptime(d, "%Y-%m-%d %H:%M").replace(tzinfo=custom_timezone_info())
 
     except Exception as e:
         capture_message(str(e), level="error")
@@ -287,14 +291,14 @@ def set_cookie(response, key, value):  # TODO
 
 def local_time():
     local_zone = tz.tzlocal()
-    dt_utc = datetime.utcnow()
+    dt_utc = tz_aware_utc_now()
     local_now = dt_utc.astimezone(local_zone)
     return local_now
 
 
 def utc_to_local(iso_str):
     local_zone = tz.tzlocal()
-    dt_utc = datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=custom_timezone_info())
+    dt_utc = datetime.datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=custom_timezone_info())
     local_now = dt_utc.astimezone(local_zone)
     return local_now
 
@@ -344,5 +348,5 @@ def contains_profane_words(text):
 def to_django_date(date):
     if not date:
         return None
-    parsed_date = datetime.strptime(date, "%a %b %d %Y %H:%M:%S GMT%z")
+    parsed_date = datetime.datetime.strptime(date, "%a %b %d %Y %H:%M:%S GMT%z")
     return parsed_date.date()

--- a/src/api/store/common.py
+++ b/src/api/store/common.py
@@ -1,25 +1,21 @@
 import csv
 import datetime
-from functools import reduce
 import io
+from functools import reduce
 from typing import List
-from django.http import FileResponse
-from _main_.settings import AWS_S3_REGION_NAME, AWS_STORAGE_BUCKET_NAME, IS_LOCAL
-from _main_.utils.common import custom_timezone_info, serialize, serialize_all, tz_aware_utc_now
-from api.constants import CSV_FIELD_NAMES
-from carbon_calculator.models import Action
-from database.utils.common import calculate_hash_for_bucket_item, get_image_size_from_bucket
-from xhtml2pdf import pisa
-from _main_.utils.utils import Console
-from api.store.utils import getCarbonScoreFromActionRel
-from database.models import Community, CommunityAdminGroup, Event, Media, Team, UserActionRel
-from django.db.models import Q, Model
-from django.utils import timezone
-import boto3
-import hashlib
-from django.db.models import Count, QuerySet
-from django.http import HttpResponse
 
+import boto3
+from django.db.models import Count, Model, Q
+from django.http import FileResponse
+from xhtml2pdf import pisa
+
+from _main_.settings import AWS_S3_REGION_NAME
+from _main_.utils.common import custom_timezone_info, serialize, serialize_all
+from api.constants import CSV_FIELD_NAMES
+from api.store.utils import getCarbonScoreFromActionRel
+from carbon_calculator.models import Action
+from database.models import Community, CommunityAdminGroup, Event, Media, Team, UserActionRel
+from database.utils.common import calculate_hash_for_bucket_item, get_image_size_from_bucket
 
 s3 = boto3.client("s3", region_name=AWS_S3_REGION_NAME)
 
@@ -39,7 +35,7 @@ def js_datetime_to_python(datetext):
 
 
 def make_time_range_from_text(time_range):
-    today = tz_aware_utc_now()
+    today = datetime.datetime.now()
     if time_range == LAST_WEEK:
         start_time = today - datetime.timedelta(days=7)
         end_time = today
@@ -50,7 +46,7 @@ def make_time_range_from_text(time_range):
     elif time_range == LAST_YEAR:
         start_time = today - datetime.timedelta(days=365)
         end_time = today
-    return [start_time.replace(tzinfo=custom_timezone_info()), end_time.replace(tzinfo=custom_timezone_info())]
+    return [start_time, end_time]
 
 
 def count_action_completed_and_todos(**kwargs):

--- a/src/api/store/common.py
+++ b/src/api/store/common.py
@@ -5,12 +5,11 @@ import io
 from typing import List
 from django.http import FileResponse
 from _main_.settings import AWS_S3_REGION_NAME, AWS_STORAGE_BUCKET_NAME, IS_LOCAL
-from _main_.utils.common import serialize, serialize_all
+from _main_.utils.common import custom_timezone_info, serialize, serialize_all
 from api.constants import CSV_FIELD_NAMES
 from carbon_calculator.models import Action
 from database.utils.common import calculate_hash_for_bucket_item, get_image_size_from_bucket
 from xhtml2pdf import pisa
-import pytz
 from _main_.utils.utils import Console
 from api.store.utils import getCarbonScoreFromActionRel
 from database.models import Community, CommunityAdminGroup, Event, Media, Team, UserActionRel
@@ -35,7 +34,8 @@ NON_EXISTENT_IMAGE = "NON_EXISTENT_IMAGE"
 def js_datetime_to_python(datetext):
     _format = "%Y-%m-%dT%H:%M:%SZ"
     _date = datetime.datetime.strptime(datetext, _format)
-    return pytz.utc.localize(_date)
+    _date = _date.replace(tzinfo=custom_timezone_info())
+    return _date
 
 
 def make_time_range_from_text(time_range):
@@ -50,7 +50,7 @@ def make_time_range_from_text(time_range):
     elif time_range == LAST_YEAR:
         start_time = today - datetime.timedelta(days=365)
         end_time = today
-    return [pytz.utc.localize(start_time), pytz.utc.localize(end_time)]
+    return [start_time.replace(tzinfo=custom_timezone_info()), end_time.replace(tzinfo=custom_timezone_info())]
 
 
 def count_action_completed_and_todos(**kwargs):

--- a/src/api/store/common.py
+++ b/src/api/store/common.py
@@ -5,7 +5,7 @@ import io
 from typing import List
 from django.http import FileResponse
 from _main_.settings import AWS_S3_REGION_NAME, AWS_STORAGE_BUCKET_NAME, IS_LOCAL
-from _main_.utils.common import custom_timezone_info, serialize, serialize_all
+from _main_.utils.common import custom_timezone_info, serialize, serialize_all, tz_aware_utc_now
 from api.constants import CSV_FIELD_NAMES
 from carbon_calculator.models import Action
 from database.utils.common import calculate_hash_for_bucket_item, get_image_size_from_bucket
@@ -39,7 +39,7 @@ def js_datetime_to_python(datetext):
 
 
 def make_time_range_from_text(time_range):
-    today = datetime.datetime.utcnow()
+    today = tz_aware_utc_now()
     if time_range == LAST_WEEK:
         start_time = today - datetime.timedelta(days=7)
         end_time = today

--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -1395,7 +1395,7 @@ class CommunityStore:
                 Q(audience=FeatureFlagConstants().for_everyone()) |
                 Q(audience=FeatureFlagConstants().for_specific_audience(), communities__id__in=communities) |
                 (Q(audience=FeatureFlagConstants().for_all_except()) & ~Q(communities__id__in=communities))
-            ).exclude(expires_on__lt=datetime.now()).prefetch_related('communities')
+            ).exclude(expires_on__lt=datetime.now(timezone.utc)).prefetch_related('communities')
             
             ff = []
             for flag in feature_flags:

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -738,10 +738,10 @@ class EventStore:
 
                 event.save()
                 exception = RecurringEventException.objects.filter(event=event).first()
-                exception.former_time = exception.former_time.replace(tzinfo=custom_timezone_info())
-                event.start_date_and_time = event.start_date_and_time.replace(tzinfo=custom_timezone_info())
+                exception_former_time = exception.former_time.replace(tzinfo=custom_timezone_info()) if exception else None
+                event_start_date_and_time = event.start_date_and_time.replace(tzinfo=custom_timezone_info())
                 
-                if exception and (exception.former_time < event.start_date_and_time):
+                if exception and (exception_former_time < event_start_date_and_time):
                     exception.delete()
 
             except Exception as e:

--- a/src/api/store/event.py
+++ b/src/api/store/event.py
@@ -3,7 +3,7 @@ import json
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
 from _main_.utils.utils import is_url_valid
-from _main_.utils.common import custom_timezone_info, local_time
+from _main_.utils.common import custom_timezone_info, local_time, tz_aware_utc_now
 from api.store.common import get_media_info, make_media_info
 from api.tests.common import RESET, makeUserUpload
 from api.utils.api_utils import is_admin_of_community
@@ -668,7 +668,7 @@ class EventStore:
         else:
             events = []
 
-        tod = datetime.datetime.utcnow()
+        tod = tz_aware_utc_now()
         today = tod.replace(tzinfo=custom_timezone_info())
 
         for event in events:

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from _main_.utils.common import tz_aware_utc_now
 from _main_.utils.constants import ME_LOGO_PNG
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
@@ -29,7 +30,7 @@ def get_schedule(schedule):
        formatted_date_string = timezone.make_aware(parsed_datetime)
        return formatted_date_string
 
-    return  datetime.utcnow() + timedelta(minutes=1)
+    return  tz_aware_utc_now() + timedelta(minutes=1)
 
 
 def get_logo(id):

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from _main_.utils.common import tz_aware_utc_now
+from _main_.utils.common import parse_datetime_to_aware
 from _main_.utils.constants import ME_LOGO_PNG
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
@@ -30,7 +30,7 @@ def get_schedule(schedule):
        formatted_date_string = timezone.make_aware(parsed_datetime)
        return formatted_date_string
 
-    return  tz_aware_utc_now() + timedelta(minutes=1)
+    return  parse_datetime_to_aware() + timedelta(minutes=1)
 
 
 def get_logo(id):

--- a/src/api/store/message.py
+++ b/src/api/store/message.py
@@ -298,7 +298,7 @@ class MessageStore:
             if message_ids:
                 with_ids = Q(id__in=message_ids)
             if is_scheduled:
-                scheduled = Q(scheduled_at__isnull=False) & Q(scheduled_at__gt=datetime.now())
+                scheduled = Q(scheduled_at__isnull=False) & Q(scheduled_at__gt=timezone.now())
 
             if context.user_is_super_admin:
                 messages = Message.objects.filter(

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -1,6 +1,6 @@
 import datetime
 
-from _main_.utils.common import custom_timezone_info
+from _main_.utils.common import custom_timezone_info, tz_aware_utc_now
 from _main_.utils.footage.FootageConstants import FootageConstants
 from api.store.common import make_time_range_from_text
 from api.store.utils import get_user_from_context
@@ -40,7 +40,7 @@ class SummaryStore:
         start_time = args.get("start_time", None)
         end_time = args.get("end_time", None)
         communities = args.get("communities", [])
-        today = datetime.datetime.utcnow()
+        today = tz_aware_utc_now()
         email = context.user_email
         is_community_admin = (
              context.user_is_community_admin

--- a/src/api/store/summary.py
+++ b/src/api/store/summary.py
@@ -1,4 +1,6 @@
 import datetime
+
+from _main_.utils.common import custom_timezone_info
 from _main_.utils.footage.FootageConstants import FootageConstants
 from api.store.common import make_time_range_from_text
 from api.store.utils import get_user_from_context
@@ -22,7 +24,6 @@ from _main_.utils.context import Context
 from sentry_sdk import capture_message
 from typing import Tuple
 from django.db.models import Q
-import pytz
 
 CUSTOM = "custom"
 
@@ -45,8 +46,8 @@ class SummaryStore:
              context.user_is_community_admin
         )
         is_super_admin = context.user_is_super_admin
-
-        today = pytz.utc.localize(today)
+        
+        today =  today.replace(tzinfo=custom_timezone_info())
         if not time_range:
             return {}, CustomMassenergizeError(
                 "Please include an appropriate date/time range"
@@ -63,8 +64,8 @@ class SummaryStore:
             _format = "%Y-%m-%dT%H:%M:%SZ"
             start_time = datetime.datetime.strptime(start_time, _format)
             end_time = datetime.datetime.strptime(end_time, _format)
-            start_time = pytz.utc.localize(start_time)
-            end_time = pytz.utc.localize(end_time)
+            start_time = start_time.replace(tzinfo=custom_timezone_info())
+            end_time = end_time.replace(tzinfo=custom_timezone_info())
         else: [start_time, end_time] = make_time_range_from_text(time_range)
         # ------------------------------------------------------
 

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -1,4 +1,4 @@
-from _main_.utils.common import serialize
+from _main_.utils.common import serialize, tz_aware_utc_now
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
 from api.constants import LOOSED_USER, STANDARD_USER,GUEST_USER
@@ -292,7 +292,7 @@ class UserStore:
                                                   "salutation":"Dear Support Team,", 
                                                   "community_name":community_names or "..."},
                                                   ME_SUPPORT_TEAM_EMAIL,pdf,filename)
-        record = PolicyAcceptanceRecords(user = user, policy=policy, signed_at = datetime.utcnow())
+        record = PolicyAcceptanceRecords(user = user, policy=policy, signed_at = tz_aware_utc_now())
         record.save()
         user.refresh_from_db()
         # ----------------------------------------------------------------

--- a/src/api/store/userprofile.py
+++ b/src/api/store/userprofile.py
@@ -1,4 +1,4 @@
-from _main_.utils.common import serialize, tz_aware_utc_now
+from _main_.utils.common import parse_datetime_to_aware, serialize
 from _main_.utils.footage.FootageConstants import FootageConstants
 from _main_.utils.footage.spy import Spy
 from api.constants import LOOSED_USER, STANDARD_USER,GUEST_USER
@@ -268,7 +268,7 @@ class UserStore:
 
       accepted = args.get("accept", False)
       key = args.get("policy_key",None)
-      current_timestamp = datetime.now()
+      current_timestamp = parse_datetime_to_aware()
       current_timestamp_str = current_timestamp.strftime('%Y-%m-%d')
       current_timestamp_str = current_timestamp_str.split(".")[0]
       username = user.full_name
@@ -292,7 +292,7 @@ class UserStore:
                                                   "salutation":"Dear Support Team,", 
                                                   "community_name":community_names or "..."},
                                                   ME_SUPPORT_TEAM_EMAIL,pdf,filename)
-        record = PolicyAcceptanceRecords(user = user, policy=policy, signed_at = tz_aware_utc_now())
+        record = PolicyAcceptanceRecords(user = user, policy=policy, signed_at = parse_datetime_to_aware())
         record.save()
         user.refresh_from_db()
         # ----------------------------------------------------------------

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.timezone import utc
 
+from _main_.utils.common import tz_aware_utc_now
 from _main_.utils.context import Context
 from _main_.utils.emailer.send_email import send_massenergize_email, send_massenergize_email_with_attachments
 from api.constants import ACTIONS, CADMIN_REPORT, CAMPAIGN_INTERACTION_PERFORMANCE_REPORT, CAMPAIGN_PERFORMANCE_REPORT, \
@@ -25,6 +26,8 @@ from task_queue.nudges.cadmin_events_nudge import generate_event_list_for_commun
 from task_queue.nudges.user_event_nudge import prepare_user_events_nudge
 from django.core.cache import cache
 from _main_.celery.app import app
+
+
 def generate_csv_and_email(data, download_type, community_name=None, email=None,filename=None):
     response = HttpResponse(content_type="text/csv")
     now = datetime.datetime.now().strftime("%Y%m%d")
@@ -209,7 +212,7 @@ def download_data(self, args, download_type):
 
 @shared_task(bind=True)
 def generate_and_send_weekly_report(self):
-    today = datetime.datetime.utcnow().replace(tzinfo=utc)
+    today = tz_aware_utc_now().replace(tzinfo=utc)
     one_week_ago = today - timezone.timedelta(days=7)
     super_admins = UserProfile.objects.filter(is_super_admin=True, is_deleted=False).values_list("email", flat=True)
 

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.timezone import utc
 
-from _main_.utils.common import tz_aware_utc_now
+from _main_.utils.common import parse_datetime_to_aware
 from _main_.utils.context import Context
 from _main_.utils.emailer.send_email import send_massenergize_email, send_massenergize_email_with_attachments
 from api.constants import ACTIONS, CADMIN_REPORT, CAMPAIGN_INTERACTION_PERFORMANCE_REPORT, CAMPAIGN_PERFORMANCE_REPORT, \
@@ -212,7 +212,7 @@ def download_data(self, args, download_type):
 
 @shared_task(bind=True)
 def generate_and_send_weekly_report(self):
-    today = tz_aware_utc_now().replace(tzinfo=utc)
+    today = parse_datetime_to_aware()
     one_week_ago = today - timezone.timedelta(days=7)
     super_admins = UserProfile.objects.filter(is_super_admin=True, is_deleted=False).values_list("email", flat=True)
 

--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -1,10 +1,13 @@
 import base64
 import time
+from zoneinfo import ZoneInfo
+
 import jwt
 from http.cookies import SimpleCookie
 from datetime import datetime, timedelta
 from django.utils import timezone
 
+from _main_.utils.common import parse_datetime_to_aware
 from _main_.utils.utils import load_json
 from ..store.utils import unique_media_filename
 from _main_.settings import SECRET_KEY
@@ -129,11 +132,14 @@ def makeEvent(**kwargs):
     community = kwargs.get("community")
     name = kwargs.get("name") or "Event default Name"
     pub_coms = kwargs.pop("communities_under_publicity", [])
+    start_date = parse_datetime_to_aware(datetime.now()+ timezone.timedelta(days=1))
+    end_date = parse_datetime_to_aware(datetime.now() + timezone.timedelta(days=2))
+    
     event = Event.objects.create(
         **{
             "is_published": True,
-            "start_date_and_time": timezone.now()+ timezone.timedelta(days=1),
-            "end_date_and_time": timezone.now() + timezone.timedelta(days=2),
+            "start_date_and_time": start_date,
+            "end_date_and_time": end_date,
             **kwargs,
             "community": community,
             "name": name,
@@ -385,8 +391,8 @@ def make_feature_flag(**kwargs):
     users = kwargs.pop("users", [])
     flag = FeatureFlag.objects.create(**{
         **kwargs,
-        "name": kwargs.get("name") or f"New Flag-{datetime.now().timestamp()}",
-        "key": kwargs.get("key") or f"New Flag-{datetime.now().timestamp()}-feature-flag",
+        "name": kwargs.get("name") or f"New Flag-{timezone.now().timestamp()}",
+        "key": kwargs.get("key") or f"New Flag-{timezone.now().timestamp()}-feature-flag",
         "notes": kwargs.get("description") or "New Flag Description",
     })
     

--- a/src/api/tests/integration/test_communities.py
+++ b/src/api/tests/integration/test_communities.py
@@ -4,7 +4,7 @@ from django.test import Client, TestCase
 
 from _main_.utils.feature_flag_keys import USER_EVENTS_NUDGES_FF
 from _main_.utils.utils import Console
-from api.tests.common import createUsers, make_feature_flag, signinAs
+from api.tests.common import createUsers, make_feature_flag, makeFlag, signinAs
 from database.models import Community, CommunityAdminGroup, CommunityMember, CommunityNotificationSetting, Goal, \
   Subdomain, UserProfile
 

--- a/src/api/tests/integration/test_events.py
+++ b/src/api/tests/integration/test_events.py
@@ -1,5 +1,9 @@
 from django.test import TestCase, Client
 from urllib.parse import urlencode
+
+from django.utils import timezone
+
+from _main_.utils.common import parse_datetime_to_aware
 from database.models import Event, EventAttendee, Community, CommunityAdminGroup, UserProfile
 from api.tests.common import signinAs, createUsers
 from datetime import datetime
@@ -34,8 +38,8 @@ class EventsTestCase(TestCase):
         self.COMMUNITY_ADMIN_GROUP = CommunityAdminGroup.objects.create(name=admin_group_name, community=self.COMMUNITY)
         self.COMMUNITY_ADMIN_GROUP.members.add(self.CADMIN)
 
-        self.startTime = datetime.now()
-        self.endTime = datetime.now()
+        self.startTime = parse_datetime_to_aware()
+        self.endTime = parse_datetime_to_aware()
         self.EVENT1 = Event.objects.create(community=self.COMMUNITY, name="event1", start_date_and_time=self.startTime, end_date_and_time=self.endTime, is_published=False)
         self.EVENT2 = Event.objects.create(community=self.COMMUNITY, name="event2", start_date_and_time=self.startTime, end_date_and_time=self.endTime, is_published=True)
         self.EVENT3 = Event.objects.create(community=self.COMMUNITY, name="event3", start_date_and_time=self.startTime, end_date_and_time=self.endTime, is_published=True)

--- a/src/api/tests/integration/test_feature_flags.py
+++ b/src/api/tests/integration/test_feature_flags.py
@@ -4,7 +4,9 @@ This is the test file for feature flags
 from datetime import datetime, timedelta
 import time
 from django.test import TestCase, Client
-from _main_.utils.common import serialize, tz_aware_utc_now
+from django.utils import timezone
+
+from _main_.utils.common import serialize
 from _main_.utils.feature_flags.FeatureFlagConstants import FeatureFlagConstants
 from _main_.utils.utils import Console
 from database.models import FeatureFlag, Community, CommunityAdminGroup
@@ -162,7 +164,7 @@ class FeatureFlagHandlerTest(TestCase):
             audience=FeatureFlagConstants.for_specific_audience(),
         )
         all_community_nudge_flag = makeFlag(name="all-community-nudge")
-        today = tz_aware_utc_now()
+        today = timezone.now()
         last_week = today - timedelta(days=7)
 
         expired_flag = makeFlag(name="expired-flag",expires_on=last_week)

--- a/src/api/tests/integration/test_feature_flags.py
+++ b/src/api/tests/integration/test_feature_flags.py
@@ -4,7 +4,7 @@ This is the test file for feature flags
 from datetime import datetime, timedelta
 import time
 from django.test import TestCase, Client
-from _main_.utils.common import serialize
+from _main_.utils.common import serialize, tz_aware_utc_now
 from _main_.utils.feature_flags.FeatureFlagConstants import FeatureFlagConstants
 from _main_.utils.utils import Console
 from database.models import FeatureFlag, Community, CommunityAdminGroup
@@ -162,7 +162,7 @@ class FeatureFlagHandlerTest(TestCase):
             audience=FeatureFlagConstants.for_specific_audience(),
         )
         all_community_nudge_flag = makeFlag(name="all-community-nudge")
-        today = datetime.utcnow()
+        today = tz_aware_utc_now()
         last_week = today - timedelta(days=7)
 
         expired_flag = makeFlag(name="expired-flag",expires_on=last_week)

--- a/src/api/tests/integration/test_message.py
+++ b/src/api/tests/integration/test_message.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from _main_.utils.common import tz_aware_utc_now
 from database.models import Community, Message
 from django.test import TestCase, Client
 from unittest.mock import patch
@@ -9,7 +10,7 @@ from _main_.utils.utils import Console
 
 
 def create_schedule(id=None):
-    in_5_days = datetime.utcnow() + timedelta(days=10 if id else 5)
+    in_5_days = tz_aware_utc_now() + timedelta(days=10 if id else 5)
     schedule = in_5_days.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
     return schedule

--- a/src/api/tests/integration/test_message.py
+++ b/src/api/tests/integration/test_message.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from _main_.utils.common import tz_aware_utc_now
+from _main_.utils.common import parse_datetime_to_aware
 from database.models import Community, Message
 from django.test import TestCase, Client
 from unittest.mock import patch
@@ -10,7 +10,7 @@ from _main_.utils.utils import Console
 
 
 def create_schedule(id=None):
-    in_5_days = tz_aware_utc_now() + timedelta(days=10 if id else 5)
+    in_5_days = parse_datetime_to_aware() + timedelta(days=10 if id else 5)
     schedule = in_5_days.strftime("%a, %d %b %Y %H:%M:%S GMT")
 
     return schedule

--- a/src/api/tests/integration/test_mou_reminder.py
+++ b/src/api/tests/integration/test_mou_reminder.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 from unittest.mock import patch, MagicMock
 
 import datetime
-from pytz import timezone
+
+from _main_.utils.common import custom_timezone_info
 from _main_.utils.policy.PolicyConstants import PolicyConstants
 from _main_.utils.utils import Console
 
@@ -25,7 +26,7 @@ class SendAdminMOUNotificationTests:
         )
 
         # Set up the current time with the UTC timezone
-        utc = timezone("UTC")
+        utc = custom_timezone_info()
         now = datetime.datetime.now(utc)
 
         # Create an admin who should receive a notification (last notified more than a month ago)

--- a/src/api/tests/unit/utils/test_parse_datetime_to_timezone_aware.py
+++ b/src/api/tests/unit/utils/test_parse_datetime_to_timezone_aware.py
@@ -1,0 +1,44 @@
+import unittest
+import zoneinfo
+from datetime import datetime
+
+from _main_.utils.common import parse_datetime_to_aware
+
+
+class TestParseDatetimeToTimezoneAware(unittest.TestCase):
+	
+	def setUp(self):
+		self.datetime_str = '2022-02-20 10:20:30'
+		self.timezone_str = 'America/New_York'
+	
+	def tearDown(self):
+		pass
+	
+	def test_parse_datetime_to_aware_without_parameters(self):
+		result = parse_datetime_to_aware()
+		expected_timezone = zoneinfo.ZoneInfo('UTC')
+		self.assertIsNotNone(result)
+		self.assertEqual(result.tzinfo, expected_timezone)
+		
+	def test_parse_datetime_to_aware_with_datetime_and_timezone_str(self):
+		result = parse_datetime_to_aware(self.datetime_str, self.timezone_str)
+		expected_naive_datetime = datetime.strptime(self.datetime_str, '%Y-%m-%d %H:%M:%S')
+		expected_timezone = zoneinfo.ZoneInfo(self.timezone_str)
+		expected_aware_datetime = expected_naive_datetime.replace(tzinfo=expected_timezone)
+		
+		self.assertIsNotNone(result)
+		self.assertEqual(result, expected_aware_datetime)
+		self.assertEqual(result.tzinfo,expected_timezone)
+	
+	def test_parse_datetime_to_aware_with_no_datetime_str(self):
+		result = parse_datetime_to_aware('', self.timezone_str)
+		self.assertIsNotNone(result)
+		self.assertEquals(result.tzinfo, zoneinfo.ZoneInfo(self.timezone_str))
+	
+	def test_parse_datetime_to_aware_with_invalid_timezone_str(self):
+		result = parse_datetime_to_aware(self.datetime_str, 'America/Invalid')
+		self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/src/api/utils/filter_functions.py
+++ b/src/api/utils/filter_functions.py
@@ -3,6 +3,7 @@ import json
 import operator
 from functools import reduce
 from django.db.models import Q
+from django.utils import timezone
 
 from database.models import CommunityMember
 
@@ -171,7 +172,7 @@ def get_messages_filter_params(params):
 
 
       if is_scheduled:
-        query.append(Q(scheduled_at__isnull=False) & Q(scheduled_at__gt=datetime.datetime.now()))
+        query.append(Q(scheduled_at__isnull=False) & Q(scheduled_at__gt=timezone.now()))
 
       if communities:
         query.append(Q(community__name__in=communities))

--- a/src/carbon_calculator/CCDefaults.py
+++ b/src/carbon_calculator/CCDefaults.py
@@ -25,7 +25,7 @@ def localized_time(time_string):
     else:   # old format 2023-10-01
         time = datetime.strptime(time_string, '%Y-%m-%d  %H:%M')
 
-    return current_tz.localize(time)
+    return time.replace(tzinfo=current_tz)
 
 def date_import(date_string):
     # Airtable changed default time format, unexpectedly.  Make it work but protect iin case it changes backj

--- a/src/carbon_calculator/carbonCalculator.py
+++ b/src/carbon_calculator/carbonCalculator.py
@@ -2,30 +2,33 @@
 # Brad Hubbard-Nelson (bradhn@mindspring.com)
 # Updated April 3
 #imports
+import csv
 import os
-import pytz
-from _main_.settings import BASE_DIR, RUN_SERVER_LOCALLY
-from datetime import datetime, date
 import time
-from .models import Action, Question, CarbonCalculatorMedia, Version, Category, Subcategory
+from datetime import date, datetime
 from io import BytesIO
+
+import requests
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.utils.text import slugify
-import csv
-import requests
-from .CCConstants import YES,NO, VALID_QUERY, INVALID_QUERY
-from .CCDefaults import getDefault, getLocality, CCD
+
+from _main_.settings import BASE_DIR, RUN_SERVER_LOCALLY
+from _main_.utils.common import custom_timezone_info
+from .CCConstants import INVALID_QUERY, NO, VALID_QUERY, YES
+from .CCDefaults import CCD, getDefault, getLocality
+from .electricity import EvalColdWaterWash, EvalCommunitySolar, EvalElectricityMonitor, EvalEnergystarRefrigerator, \
+    EvalEnergystarWasher, EvalHeatPumpDryer, EvalInductionStove, EvalLEDLighting, EvalLineDry, EvalRefrigeratorPickup, \
+    EvalRenewableElectricity, EvalSmartPowerStrip
+from .foodWaste import EvalCompost, EvalLowCarbonDiet, EvalReduceWaste
+from .homeHeating import EvalAirSourceHeatPump, EvalEfficientBoilerFurnace, EvalEnergyAudit, EvalGroundSourceHeatPump, \
+    EvalHeatingSystemAssessment, EvalProgrammableThermostats, EvalWeatherization
+from .hotWater import EvalHeatPumpWaterHeater, EvalHotWaterAssessment, EvalSolarHW
+from .landscaping import EvalElectricMower, EvalRakeOrElecBlower, EvalReduceLawnCare, EvalReduceLawnSize
+from .models import Action, CarbonCalculatorMedia, Category, Question, Subcategory, Version
 from .queries import QuerySingleAction
-from .homeHeating import EvalEnergyAudit, EvalWeatherization, EvalProgrammableThermostats, EvalAirSourceHeatPump, \
-                        EvalGroundSourceHeatPump, EvalHeatingSystemAssessment, EvalEfficientBoilerFurnace
-from .electricity import EvalCommunitySolar, EvalRenewableElectricity, EvalLEDLighting, EvalEnergystarRefrigerator, \
-                        EvalEnergystarWasher, EvalInductionStove, EvalHeatPumpDryer, EvalColdWaterWash, EvalLineDry, \
-                        EvalRefrigeratorPickup, EvalSmartPowerStrip, EvalElectricityMonitor
 from .solar import EvalSolarAssessment, EvalSolarPV
-from .hotWater import EvalHotWaterAssessment, EvalHeatPumpWaterHeater, EvalSolarHW
-from .transportation import EvalReplaceCar, EvalReduceMilesDriven, EvalEliminateCar, EvalReduceFlights, EvalOffsetFlights
-from .foodWaste import EvalLowCarbonDiet, EvalReduceWaste, EvalCompost
-from .landscaping import EvalReduceLawnSize, EvalReduceLawnCare, EvalRakeOrElecBlower, EvalElectricMower
+from .transportation import EvalEliminateCar, EvalOffsetFlights, EvalReduceFlights, EvalReduceMilesDriven, \
+    EvalReplaceCar
 
 CALCULATOR_VERSION = "4.0.5"
 QUESTIONS_DATA = BASE_DIR + "/carbon_calculator/content/Questions.csv"
@@ -38,7 +41,7 @@ TOKEN_POINTS = 15
 def fileDateTime(path):
     # file modification
     timestamp = os.path.getmtime(path)
-    utc=pytz.UTC
+    utc=custom_timezone_info()
 
     # convert timestamp into DateTime object
     datestamp = datetime.fromtimestamp(timestamp).replace(tzinfo=utc)

--- a/src/socket_notifications/consumers/user_session_tracker_consumer.py
+++ b/src/socket_notifications/consumers/user_session_tracker_consumer.py
@@ -5,8 +5,8 @@ import asyncio
 from asgiref.sync import async_to_sync
 import time
 from threading import Timer
-import pytz
 
+from _main_.utils.common import custom_timezone_info
 from api.constants import WHEN_USER_AUTHENTICATED_SESSION_EXPIRES
 
 USER_SESSION_RENEWED = "user_session_renewed"
@@ -31,7 +31,7 @@ class UserSessionTrackerConsumer(AsyncWebsocketConsumer):
         if not session: return None
         expiration_in_session = session.get(WHEN_USER_AUTHENTICATED_SESSION_EXPIRES)
         in_seconds = expiration_in_session / 1000
-        expiration_as_date = datetime.fromtimestamp(in_seconds, tz=pytz.UTC)
+        expiration_as_date = datetime.fromtimestamp(in_seconds, tz=custom_timezone_info())
         return expiration_as_date
     
     async def send_auth_notification(self):
@@ -58,7 +58,7 @@ class UserSessionTrackerConsumer(AsyncWebsocketConsumer):
        
     async def check_expiry(self, expiration_as_date, func, wait_time = WAIT_TIME):
         while True:
-            current_date_and_time = datetime.now(tz=pytz.UTC)
+            current_date_and_time = datetime.now(tz=custom_timezone_info())
             if current_date_and_time > expiration_as_date:
                 await func()
                 break

--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -1,19 +1,18 @@
-from _main_.utils.common import encode_data_for_URL, serialize_all
-from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
-from _main_.utils.constants import ADMIN_URL_ROOT, COMMUNITY_URL_ROOT
-from _main_.utils.feature_flag_keys import COMMUNITY_ADMIN_WEEKLY_EVENTS_NUDGE_FF
-from api.utils.api_utils import get_sender_email
-from api.utils.constants import WEEKLY_EVENTS_NUDGE_TEMPLATE
-from database.utils.settings.model_constants.events import EventConstants
-from database.models import Community, FeatureFlag, UserProfile, Event, CommunityAdminGroup
-from database.utils.settings.admin_settings import AdminPortalSettings
-from database.utils.settings.user_settings import UserPortalSettings
-from django.utils import timezone
 import datetime
-import pytz
-from django.db.models import Q
-from dateutil.relativedelta import relativedelta
 
+from dateutil.relativedelta import relativedelta
+from django.db.models import Q
+from django.utils import timezone
+
+from _main_.utils.common import custom_timezone_info, encode_data_for_URL, serialize_all
+from _main_.utils.constants import ADMIN_URL_ROOT, COMMUNITY_URL_ROOT
+from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
+from _main_.utils.feature_flag_keys import COMMUNITY_ADMIN_WEEKLY_EVENTS_NUDGE_FF
+from api.utils.constants import WEEKLY_EVENTS_NUDGE_TEMPLATE
+from database.models import Community, CommunityAdminGroup, Event, FeatureFlag, UserProfile
+from database.utils.settings.admin_settings import AdminPortalSettings
+from database.utils.settings.model_constants.events import EventConstants
+from database.utils.settings.user_settings import UserPortalSettings
 from task_queue.helpers import get_event_location
 
 WEEKLY = "weekly"
@@ -21,7 +20,7 @@ BI_WEEKLY = "bi-weekly"
 MONTHLY = "monthly"
 
 #kludge - current communities are in Massachusetts, so for now all dates shown are eastern us time zone
-eastern_tz = pytz.timezone("US/Eastern")
+eastern_tz = custom_timezone_info("US/Eastern")
 
 default_pref = {
     "user_portal_settings": UserPortalSettings.Defaults,

--- a/src/task_queue/nudges/user_event_nudge.py
+++ b/src/task_queue/nudges/user_event_nudge.py
@@ -1,6 +1,5 @@
 import datetime
-import pytz
-from _main_.utils.common import encode_data_for_URL, serialize_all
+from _main_.utils.common import custom_timezone_info, encode_data_for_URL, serialize_all
 from _main_.utils.constants import COMMUNITY_URL_ROOT
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 from _main_.utils.feature_flag_keys import USER_EVENTS_NUDGES_FF
@@ -24,7 +23,7 @@ BI_WEEKLY = "biweekly"
 MONTHLY = "per_month"
 DAILY = "per_day"
 
-eastern_tz = pytz.timezone("US/Eastern")
+eastern_tz = custom_timezone_info("US/Eastern")
 
 LIMIT = 5
 

--- a/src/task_queue/views.py
+++ b/src/task_queue/views.py
@@ -1,5 +1,6 @@
 import csv
 from django.http import HttpResponse
+from _main_.utils.common import tz_aware_utc_now
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 from _main_.settings import IS_PROD
 from _main_.utils.constants import ADMIN_URL_ROOT
@@ -18,7 +19,7 @@ from django.db.models import Q
 from django.core.exceptions import ObjectDoesNotExist
 from carbon_calculator.carbonCalculator import AverageImpact
 
-today = datetime.datetime.utcnow().replace(tzinfo=utc)
+today = tz_aware_utc_now().replace(tzinfo=utc)
 one_week_ago = today - timezone.timedelta(days=7)
 communities = Community.objects.all().order_by("is_approved")
 

--- a/src/task_queue/views.py
+++ b/src/task_queue/views.py
@@ -1,6 +1,6 @@
 import csv
 from django.http import HttpResponse
-from _main_.utils.common import tz_aware_utc_now
+from _main_.utils.common import parse_datetime_to_aware
 from _main_.utils.emailer.send_email import send_massenergize_email_with_attachments
 from _main_.settings import IS_PROD
 from _main_.utils.constants import ADMIN_URL_ROOT
@@ -19,7 +19,7 @@ from django.db.models import Q
 from django.core.exceptions import ObjectDoesNotExist
 from carbon_calculator.carbonCalculator import AverageImpact
 
-today = tz_aware_utc_now().replace(tzinfo=utc)
+today = parse_datetime_to_aware()
 one_week_ago = today - timezone.timedelta(days=7)
 communities = Community.objects.all().order_by("is_approved")
 


### PR DESCRIPTION
####  Summary / Highlights
This pull request addresses two deprecations issues in Django 4:

 - The `pytz` package for timezone handling is deprecated in Django 4 and all occurrences of `pytz` have been refactored to use `zoneinfo.ZoneInfo`.

- The `datetime.datetime.utcnow()` function is deprecated and all occurrences of `datetime.datetime.utcnow()` have been replaced with the recommended `datetime.now(timezone.utc)` to ensure timezone-aware datetime objects in UTC.


#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
