### PR TITLE
Fix: Bug loading all feature flags to the user portal.

### DIFF
--- a/src/api/store/community.py
+++ b/src/api/store/community.py
@@ -23,10 +23,11 @@ from api.tests.common import RESET
 from api.utils.api_utils import get_distance_between_coords, is_admin_of_community
 from api.utils.filter_functions import get_communities_filter_params
 from database.models import AboutUsPageSettings, Action, ActionsPageSettings, Community, CommunityAdminGroup, \
-	CommunityMember, CommunityNotificationSetting, ContactUsPageSettings, CustomCommunityWebsiteDomain, \
-	DonatePageSettings, EventsPageSettings, FeatureFlag, Goal, Graph, HomePageSettings, ImpactPageSettings, Location, \
-	Media, RealEstateUnit, RegisterPageSettings, SigninPageSettings, Subdomain, TeamsPageSettings, \
-	TestimonialsPageSettings, UserProfile, VendorsPageSettings
+    CommunityMember, CommunityNotificationSetting, ContactUsPageSettings, CustomCommunityWebsiteDomain, \
+    DonatePageSettings, EventsPageSettings, FeatureFlag, get_enabled_flags, Goal, Graph, HomePageSettings, \
+    ImpactPageSettings, Location, \
+    Media, RealEstateUnit, RegisterPageSettings, SigninPageSettings, Subdomain, TeamsPageSettings, \
+    TestimonialsPageSettings, UserProfile, VendorsPageSettings
 from database.utils.common import json_loader
 from .utils import (get_community, get_community_or_die, get_new_title, get_user_from_context, is_reu_in_community)
 from ..constants import COMMUNITY_NOTIFICATION_TYPES
@@ -1381,7 +1382,7 @@ class CommunityStore:
                 if not community:
                     return None, CustomMassenergizeError("Community not found")
                 
-                communities = [community.id]
+                return get_enabled_flags(community), None
             else:
                 # check if user is a community admin, get all communities they are admin of
                 user = get_user_from_context(context)
@@ -1392,8 +1393,8 @@ class CommunityStore:
             
             feature_flags = FeatureFlag.objects.filter(
                 Q(audience=FeatureFlagConstants().for_everyone()) |
-                Q(audience=FeatureFlagConstants().for_specific_audience(), communities__in=communities) |
-                (Q(audience=FeatureFlagConstants().for_all_except()) & ~Q(communities__in=communities))
+                Q(audience=FeatureFlagConstants().for_specific_audience(), communities__id__in=communities) |
+                (Q(audience=FeatureFlagConstants().for_all_except()) & ~Q(communities__id__in=communities))
             ).exclude(expires_on__lt=datetime.now()).prefetch_related('communities')
             
             ff = []

--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -381,11 +381,19 @@ def make_vendor(**kwargs):
     return vendor
 
 def make_feature_flag(**kwargs):
+    communities = kwargs.pop("communities", [])
+    users = kwargs.pop("users", [])
     flag = FeatureFlag.objects.create(**{
         **kwargs,
         "name": kwargs.get("name") or f"New Flag-{datetime.now().timestamp()}",
-        "key": kwargs.get("key") or f"New Flag-{datetime.now().timestamp()}",
+        "key": kwargs.get("key") or f"New Flag-{datetime.now().timestamp()}-feature-flag",
         "notes": kwargs.get("description") or "New Flag Description",
     })
+    
+    if communities:
+        flag.communities.set(communities)
+    if users:
+        flag.users.set(users)
+    flag.save()
 
     return flag

--- a/src/api/tests/integration/test_communities.py
+++ b/src/api/tests/integration/test_communities.py
@@ -1,18 +1,15 @@
-from datetime import datetime
-
-from django.test import TestCase, Client
-from django.conf import settings as django_settings
 from urllib.parse import urlencode
-from _main_.settings import BASE_DIR
+
+from django.test import Client, TestCase
+
 from _main_.utils.feature_flag_keys import USER_EVENTS_NUDGES_FF
-from _main_.utils.massenergize_response import MassenergizeResponse
-from database.models import CommunityNotificationSetting, Team, Community, UserProfile, Goal, TeamMember, \
-  CommunityMember, RealEstateUnit, CommunityAdminGroup, Subdomain
-from _main_.utils.utils import Console, load_json
-from api.tests.common import make_feature_flag, signinAs, createUsers
+from _main_.utils.utils import Console
+from api.tests.common import createUsers, make_feature_flag, signinAs
+from database.models import Community, CommunityAdminGroup, CommunityMember, CommunityNotificationSetting, Goal, \
+  Subdomain, UserProfile
+
 
 class CommunitiesTestCase(TestCase):
-
 
   @classmethod
   def setUpClass(self):
@@ -33,6 +30,13 @@ class CommunitiesTestCase(TestCase):
       'is_published': True,
       'is_approved': True
     })
+    
+    self.TEST_COMMUNTITY = Community.objects.create(**{
+        'subdomain': "test_community-unique",
+        'name': "test_community_unique",
+        'accepted_terms_and_conditions': True,
+        'is_approved': True
+        })
 
     # also reserve the subdomain
     Subdomain.objects.create(name=self.COMMUNITY.subdomain.lower(), community=self.COMMUNITY, in_use=True)
@@ -100,6 +104,9 @@ class CommunitiesTestCase(TestCase):
     self.community_notification_setting = CommunityNotificationSetting.objects.create(community=self.COMMUNITY, is_active=False,
                                                                notification_type=USER_EVENTS_NUDGES_FF)
     self.ff = make_feature_flag(key=f"test_{USER_EVENTS_NUDGES_FF}")
+    self.ff1 = make_feature_flag(audience="SPECIFIC", communities=[self.COMMUNITY])
+    self.ff2 = make_feature_flag(audience="ALL_EXCEPT", communities=[self.COMMUNITY, self.TEST_COMMUNTITY], key="test_all_except", name="Test All Except")
+    self.ff3 = make_feature_flag(audience="EVERYONE", key="test_everyone", name="Test Everyone")
     
   @classmethod
   def tearDownClass(self):
@@ -489,16 +496,21 @@ class CommunitiesTestCase(TestCase):
     # test list community feature flags not logged in
     Console.header("Integration: list_communities_feature_flags")
     url = "/api/communities.features.flags.list"
-    args = {"community_id": self.COMMUNITY.id}
+    args = {"community_id": self.COMMUNITY2.id}
     
     signinAs(self.client, None)
     list_response = self.client.post(url, urlencode(args), content_type="application/x-www-form-urlencoded").toDict()
     self.assertTrue(list_response["success"])
+    self.assertIn({ "id":self.ff3.id,"name": "Test Everyone",  "key": "test_everyone"}, list_response["data"])
+    self.assertIn({"id":self.ff2.id,  "name": "Test All Except", "key": "test_all_except"}, list_response["data"])
     
     # test list community feature flags logged as user
     signinAs(self.client, self.USER)
-    list_response = self.client.post(url, urlencode(args), content_type="application/x-www-form-urlencoded").toDict()
+    list_response = self.client.post(url, urlencode({"community_id":self.TEST_COMMUNTITY.id}), content_type="application/x-www-form-urlencoded").toDict()
     self.assertTrue(list_response["success"])
+    self.assertIsInstance(list_response["data"], list)
+    self.assertIn({ "id":self.ff3.id,"name": "Test Everyone",  "key": "test_everyone"}, list_response["data"])
+    self.assertNotIn({"id":self.ff2.id,  "name": "Test All Except", "key": "test_all_except"}, list_response["data"])
     
     # test list community feature flags logged as user with invalid subdomain
     signinAs(self.client, self.USER)
@@ -509,6 +521,7 @@ class CommunitiesTestCase(TestCase):
     signinAs(self.client, self.CADMIN)
     list_response = self.client.post(url, urlencode({}), content_type="application/x-www-form-urlencoded").toDict()
     self.assertTrue(list_response["success"])
+    self.assertIsInstance(list_response["data"], list)
     
     # test list community feature flags logged as sadmin
     signinAs(self.client, self.SADMIN)
@@ -548,7 +561,6 @@ class CommunitiesTestCase(TestCase):
     # test list community features logged as sadmin
     signinAs(self.client, self.SADMIN)
     list_response = self.client.post(url, urlencode(args), content_type="application/x-www-form-urlencoded").toDict()
-    print("====> ", list_response)
     self.assertTrue(list_response["success"])
     self.assertIsInstance(list_response["data"], dict)
     


### PR DESCRIPTION
####  Summary / Highlights
This pull request addresses a critical bug affecting the loading of feature flags into the user portal. With this fix, users wouldn't see features that are not open to their communities.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

https://github.com/massenergize/api/assets/42780120/b4b5821a-6c73-42cb-9f61-cf658c1b7557


#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [ ] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
