### PR TITLE
1112 - Event sharing email should include our own events

### DIFF
--- a/src/task_queue/nudges/cadmin_events_nudge.py
+++ b/src/task_queue/nudges/cadmin_events_nudge.py
@@ -47,7 +47,7 @@ def generate_event_list_for_community(com):
         community__is_published=True,
         is_published=True,
         is_deleted=False
-    ).exclude(community=com).exclude(shared_to__id=com.id).distinct().order_by("start_date_and_time")
+    ).exclude(shared_to__id=com.id).distinct().order_by("start_date_and_time")
     
     return {
         "events": prepare_events_email_data(events),


### PR DESCRIPTION
Minor change to the event sharing email to include the events that are hosted by the community receiving the email