### PR TITLE
Hotfix: Hide rewiring America under feature flag

### DIFF
--- a/src/_main_/utils/common.py
+++ b/src/_main_/utils/common.py
@@ -269,9 +269,12 @@ def extract_location(args):
 #     return False
 
 def is_value(b):
-    if b and b not in ["undefined", "null", "None", ""]:
-        return True
-    return False
+    if isinstance(b, str) and b.lower() in {"undefined", "null", "none"}:
+        return False
+    if b is None:
+        return False
+
+    return True
 
 
 # def resize_image(img, options={}):

--- a/src/_main_/utils/feature_flag_keys.py
+++ b/src/_main_/utils/feature_flag_keys.py
@@ -4,3 +4,5 @@ COMMUNITY_ADMIN_WEEKLY_EVENTS_NUDGE_FF = "weekly-event-nudge-feature-flag"
 #UPDATE_HTML_CONTENT_FORMAT_FF = "update-html-format-feature-flag"
 REMOVE_DUPLICATE_IMAGE_FF = "remove-duplicate-images-feature-flag"
 UPDATE_ACTIONS_CONTENT_FF = "update-actions-content-feature-flag"
+
+REWIRING_AMERICA_MENU_ITEM_FF = "rewiring-america-menu-item-feature-flag"

--- a/src/api/constants.py
+++ b/src/api/constants.py
@@ -1,4 +1,4 @@
-from _main_.utils.feature_flag_keys import USER_EVENTS_NUDGES_FF
+from _main_.utils.feature_flag_keys import REWIRING_AMERICA_MENU_ITEM_FF, USER_EVENTS_NUDGES_FF
 
 USERS = "users"
 COMMUNITIES = 'communities'
@@ -40,3 +40,6 @@ CSV_FIELD_NAMES = [
 
 COMMUNITY_NOTIFICATION_TYPES = [USER_EVENTS_NUDGES_FF]
 
+MENU_CONTROL_FEATURE_FLAGS = {
+  '/rewiring-america': REWIRING_AMERICA_MENU_ITEM_FF,
+}

--- a/src/api/tests/unit/utils/test_common.py
+++ b/src/api/tests/unit/utils/test_common.py
@@ -6,34 +6,34 @@ class TestIsValue(unittest.TestCase):
     def test_is_value(self):
         # Test when b is None
         self.assertFalse(is_value(None))
-        
+
         # Test when b is "undefined"
         self.assertFalse(is_value("undefined"))
-        
+
         # Test when b is "null"
         self.assertFalse(is_value("null"))
-        
+
         # Test when b is "None"
         self.assertFalse(is_value("None"))
-        
+
         # Test when b is an empty string
-        self.assertFalse(is_value(""))
-        
+        self.assertTrue(is_value(""))
+
         # Test when b is True
         self.assertTrue(is_value(True))
-        
+
         # Test when b is False
-        self.assertFalse(is_value(False))
-        
+        self.assertTrue(is_value(False))
+
         # Test when b is a non-empty string
         self.assertTrue(is_value("Hello World"))
-        
+
         # Test when b is a numeric value
         self.assertTrue(is_value(123))
-        
+
         # Test when b is a list
         self.assertTrue(is_value([1, 2, 3]))
-        
+
         # Test when b is a dictionary
         self.assertTrue(is_value({"key": "value"}))
 

--- a/src/api/utils/api_utils.py
+++ b/src/api/utils/api_utils.py
@@ -267,23 +267,23 @@ def prepare_menu_items_for_portal(content, prefix):
             
         return prepared_menu_items
 
-def remove_unpublished_items(content):
+def remove_unpublished_menu_items(content, links_to_hide=[]):
     if not content:
         return None
 
     published_items = []
-    
+
     for item in content:
         if not item.get("children"):
-            if item.get("is_published"):
+            if item.get("is_published") and item.get("link") not in links_to_hide:
                 published_items.append(item)
         else:
             if not item.get("is_published"):
                 continue
-            item["children"] = remove_unpublished_items(item["children"])
+            item["children"] = remove_unpublished_menu_items(item["children"], links_to_hide)
             if item["children"]:
                 published_items.append(item)
-            
+                
     return published_items
 
 


### PR DESCRIPTION
####  Summary / Highlights
This PR implements a feature that allows hiding menu items under feature flags. With this implementation, the rewiring-america route on the frontend is now controlled by a feature flag.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
https://github.com/user-attachments/assets/17a255df-f794-49fd-9c26-653bbd625695

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
