### PR TITLE
fix: Add dates to translation exclusion list

### DIFF
--- a/src/_main_/utils/translation/__init__.py
+++ b/src/_main_/utils/translation/__init__.py
@@ -7,7 +7,7 @@ from database.models import TranslationsCache
 import json_flatten
 
 JSON_EXCLUDE_KEYS = {
-    'id', 'pk', 'file', 'media', 'date', 'link', 'url', 'icon', 'key', 'slug'
+    'id', 'pk', 'file', 'media', 'date', 'link', 'url', 'icon', 'key', 'slug',"created_at", "updated_at"
 }
 
 JSON_EXCLUDE_VALUES = {
@@ -28,6 +28,7 @@ EXCLUDED_JSON_VALUE_PATTERNS = [
     re.compile("(https?://)?\w+(\.\w+)+"),                                          #  URL_REGEX
     re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),     #  UUID_REGEX
     re.compile(r'\b(\d{4})-(0?[1-9]|1[0-2])-(0?[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)\.(\d{3})Z\b'),                     #  DATE_REGEX
+    re.compile(r'\b(\d{4})-(0?[1-9]|1[0-2])-(0?[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)Z\b'),                     #  DATE_REGEX
     re.compile("\d{4}-\d{2}-\d{2}"),                                                #  SHORT_DATE_REGEX
 ]
 


### PR DESCRIPTION
####  Summary / Highlights
This pull request enhances the codebase by adding `created_at` and `updated_at` to the `JSON_EXCLUDE_KEYS` list. Additionally, a new regex pattern has been introduced to filter out date and datetime values.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
