### PR TITLE
✨ feat: add support for UUID in campaign ID lookup

### DIFF
--- a/src/_main_/utils/error_messages.py
+++ b/src/_main_/utils/error_messages.py
@@ -1,0 +1,9 @@
+
+INVALID_LANGUAGE_CODE_ERR_MSG = "Invalid language code provided: {}"
+CAMPAIGN_NOT_FOUND_ERR_MSG = "Campaign not found"
+MISSING_CAMPAIGN_ID_ERR_MSG = "Please provide a campaign_id"
+MISSING_SUPPORTED_LANGUAGES_ERR_MSG = "Please provide supported_languages"
+CAMPAIGN_DOES_NOT_EXIST_ERR_MSG = "Campaign with id({}) does not exist"
+PERMISSION_DENIED_ERROR_MSG = "permission_denied"
+NO_SUPPORTED_LANGUAGE_FOUND_ERR_MSG = "No supported language found with the provided code"
+MISSING_REQUIRED_FIELD_ERROR_MSG = "You are Missing a Required Input: {}"

--- a/src/api/store/supported_language.py
+++ b/src/api/store/supported_language.py
@@ -5,6 +5,7 @@ from _main_.utils.activity_logger import log
 from typing import Tuple
 from django.db import IntegrityError
 from _main_.utils.constants import DEFAULT_SOURCE_LANGUAGE_CODE, INVALID_LANGUAGE_CODE_ERR_MSG
+from uuid import UUID
 
 
 class SupportedLanguageStore:
@@ -143,10 +144,15 @@ class SupportedLanguageStore:
             if not campaign_id:
                 return None, CustomMassenergizeError("Please provide a campaign_id")
             
-            campaign = Campaign.objects.filter(pk=campaign_id).first()
+            campaign = None
+            try:
+                uuid_id = UUID(campaign_id, version=4)
+                campaign = Campaign.objects.filter(id=uuid_id, is_deleted=False).first()
+            except ValueError:
+                campaign = Campaign.objects.filter(slug=campaign_id, is_deleted=False).first()
             
             if not campaign:
-                return None, CustomMassenergizeError("Campaign not found")
+                return None, CustomMassenergizeError("Campaign with id does not exist")
             
             campaign_supported_languages = campaign.supported_languages.all()
             all_supported_languages = SupportedLanguage.objects.all()

--- a/src/api/store/supported_language.py
+++ b/src/api/store/supported_language.py
@@ -152,7 +152,7 @@ class SupportedLanguageStore:
                 campaign = Campaign.objects.filter(slug=campaign_id, is_deleted=False).first()
             
             if not campaign:
-                return None, CustomMassenergizeError("Campaign with id does not exist")
+                return None, CustomMassenergizeError(f"Campaign with id({campaign_id}) does not exist")
             
             campaign_supported_languages = campaign.supported_languages.all()
             all_supported_languages = SupportedLanguage.objects.all()

--- a/src/api/store/supported_language.py
+++ b/src/api/store/supported_language.py
@@ -1,3 +1,5 @@
+from _main_.utils.error_messages import CAMPAIGN_DOES_NOT_EXIST_ERR_MSG, MISSING_CAMPAIGN_ID_ERR_MSG, \
+    MISSING_SUPPORTED_LANGUAGES_ERR_MSG
 from apps__campaigns.models import Campaign
 from database.models import CampaignSupportedLanguage, SupportedLanguage
 from _main_.utils.massenergize_errors import CustomMassenergizeError
@@ -84,15 +86,15 @@ class SupportedLanguageStore:
             supported_languages_dict = args.get('supported_languages', None)
             
             if not campaign_id:
-                return None, CustomMassenergizeError("Please provide a campaign_id")
+                return None, CustomMassenergizeError(MISSING_CAMPAIGN_ID_ERR_MSG)
                 
             campaign = Campaign.objects.get(pk=campaign_id)
             
             if not campaign:
-                return None, CustomMassenergizeError("Campaign not found")
+                return None, CustomMassenergizeError(CAMPAIGN_DOES_NOT_EXIST_ERR_MSG.format(campaign_id))
             
             if not supported_languages_dict:
-                return None, CustomMassenergizeError("Please provide supported_languages")
+                return None, CustomMassenergizeError(MISSING_SUPPORTED_LANGUAGES_ERR_MSG)
             
             supported_languages_codes = list(supported_languages_dict.keys())
             
@@ -142,7 +144,7 @@ class SupportedLanguageStore:
             campaign_id = args.get('campaign_id', None)
             
             if not campaign_id:
-                return None, CustomMassenergizeError("Please provide a campaign_id")
+                return None, CustomMassenergizeError(MISSING_CAMPAIGN_ID_ERR_MSG)
             
             campaign = None
             try:
@@ -152,7 +154,7 @@ class SupportedLanguageStore:
                 campaign = Campaign.objects.filter(slug=campaign_id, is_deleted=False).first()
             
             if not campaign:
-                return None, CustomMassenergizeError(f"Campaign with id({campaign_id}) does not exist")
+                return None, CustomMassenergizeError(CAMPAIGN_DOES_NOT_EXIST_ERR_MSG.format(campaign_id))
             
             campaign_supported_languages = campaign.supported_languages.all()
             all_supported_languages = SupportedLanguage.objects.all()

--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -422,25 +422,22 @@ def make_campaign_account(**kwargs):
     creator = kwargs.get("creator") or makeAdmin()
     community = kwargs.get("community") or makeCommunity()
     subdomain = kwargs.get("subdomain") or f"test.campaign.account-{datetime.now().timestamp()}"
-    account = CampaignAccount.objects.create(**{
+    return CampaignAccount.objects.create(**{
         "name": "Test Campaign Account",
         "creator": creator,
         "community": community,
         "subdomain": subdomain,
     })
-    return account
 
 def make_campaign(**kwargs):
     title = kwargs.get("title") or f"New Campaign-{datetime.now().timestamp()}"
     desc = kwargs.get("description") or "New Campaign Description"
     account = kwargs.get("account") or make_campaign_account()
     
-    c = Campaign.objects.create(**{
+    return Campaign.objects.create(**{
         **kwargs,
         "title": title,
         "tagline": kwargs.get("tagline") or "New Campaign Tagline",
         "description": desc,
         "account": account,
     })
-
-    return c

--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -36,7 +36,7 @@ import requests
 from io import BytesIO
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
-from apps__campaigns.models import Technology
+from apps__campaigns.models import Campaign, CampaignAccount, Technology
 
 from database.models import Vendor
 from ..utils.api_utils import load_default_menus_from_json
@@ -409,3 +409,38 @@ def make_feature_flag(**kwargs):
 def make_supported_language(code=f"en-US-{datetime.now().timestamp()}", name="English (US)"):
     lang = SupportedLanguage.objects.create(code=code, name=name)
     return lang
+
+
+def create_supported_language(**kwargs):
+    code = kwargs.get("code") or f"en-US-{datetime.now().timestamp()}"
+    name = kwargs.get("name") or "English (US)"
+    lang = SupportedLanguage.objects.create(code=code, name=name)
+    return lang
+
+
+def make_campaign_account(**kwargs):
+    creator = kwargs.get("creator") or makeAdmin()
+    community = kwargs.get("community") or makeCommunity()
+    subdomain = kwargs.get("subdomain") or f"test.campaign.account-{datetime.now().timestamp()}"
+    account = CampaignAccount.objects.create(**{
+        "name": "Test Campaign Account",
+        "creator": creator,
+        "community": community,
+        "subdomain": subdomain,
+    })
+    return account
+
+def make_campaign(**kwargs):
+    title = kwargs.get("title") or f"New Campaign-{datetime.now().timestamp()}"
+    desc = kwargs.get("description") or "New Campaign Description"
+    account = kwargs.get("account") or make_campaign_account()
+    
+    c = Campaign.objects.create(**{
+        **kwargs,
+        "title": title,
+        "tagline": kwargs.get("tagline") or "New Campaign Tagline",
+        "description": desc,
+        "account": account,
+    })
+
+    return c

--- a/src/api/tests/integration/test_supported_languages.py
+++ b/src/api/tests/integration/test_supported_languages.py
@@ -142,7 +142,7 @@ class SuppportedLanguagesTest(TestCase):
         response = self.make_request("campaigns.supported_languages.list", {"campaign_id": "invalid"})
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], 'Campaign with id does not exist')
+        self.assertEqual(response["error"], f"Campaign with id(invalid) does not exist")
         
     def test_list_campaign_supported_languages_without_UUID(self):
         Console.header("Testing fetch all supported languages")
@@ -163,7 +163,7 @@ class SuppportedLanguagesTest(TestCase):
         response = self.make_request("campaigns.supported_languages.list", {"campaign_id": "invalid"})
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "Campaign with id does not exist")
+        self.assertEqual(response["error"], "Campaign with id(invalid) does not exist")
         
     def test_update_campaign_supported_languages_with_correct_data(self):
         Console.header("Testing update supported languages")

--- a/src/api/tests/integration/test_supported_languages.py
+++ b/src/api/tests/integration/test_supported_languages.py
@@ -7,6 +7,9 @@ from django.test import TestCase, Client
 from unittest.mock import patch
 
 from _main_.utils.constants import INVALID_LANGUAGE_CODE_ERR_MSG
+from _main_.utils.error_messages import CAMPAIGN_DOES_NOT_EXIST_ERR_MSG, MISSING_REQUIRED_FIELD_ERROR_MSG, \
+    NO_SUPPORTED_LANGUAGE_FOUND_ERR_MSG, \
+    PERMISSION_DENIED_ERROR_MSG
 from api.tests.common import create_supported_language, make_campaign, signinAs, createUsers, make_supported_language, \
     makeCommunity
 from _main_.utils.utils import Console, load_json
@@ -93,7 +96,7 @@ class SuppportedLanguagesTest(TestCase):
         response = self.make_request(self.create_path, data)
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "permission_denied")
+        self.assertEqual(response["error"], PERMISSION_DENIED_ERROR_MSG)
 
     def test_supported_languages_info(self):
         Console.header("Testing fetch supported language info")
@@ -118,7 +121,7 @@ class SuppportedLanguagesTest(TestCase):
         response = self.make_request(self.info_path, {"language_code": "invalid"})
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "No supported language found with the provided code")
+        self.assertEqual(response["error"], NO_SUPPORTED_LANGUAGE_FOUND_ERR_MSG)
 
     def test_get_supported_languages(self):
         Console.header("Testing fetch all supported languages")
@@ -142,14 +145,14 @@ class SuppportedLanguagesTest(TestCase):
         response = self.make_request("campaigns.supported_languages.list", {"campaign_id": "invalid"})
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], f"Campaign with id(invalid) does not exist")
+        self.assertEqual(response["error"], CAMPAIGN_DOES_NOT_EXIST_ERR_MSG.format("invalid"))
         
     def test_list_campaign_supported_languages_without_UUID(self):
         Console.header("Testing fetch all supported languages")
         response = self.make_request("campaigns.supported_languages.list")
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "You are Missing a Required Input: Campaign Id")
+        self.assertEqual(response["error"], MISSING_REQUIRED_FIELD_ERROR_MSG.format("Campaign Id"))
         
     def test_list_campaign_supported_languages_with_slug(self):
         Console.header("Testing fetch all supported languages")
@@ -163,7 +166,7 @@ class SuppportedLanguagesTest(TestCase):
         response = self.make_request("campaigns.supported_languages.list", {"campaign_id": "invalid"})
 
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "Campaign with id(invalid) does not exist")
+        self.assertEqual(response["error"], CAMPAIGN_DOES_NOT_EXIST_ERR_MSG.format("invalid"))
         
     def test_update_campaign_supported_languages_with_correct_data(self):
         Console.header("Testing update supported languages")
@@ -176,10 +179,11 @@ class SuppportedLanguagesTest(TestCase):
         Console.header("Testing update supported languages")
         response = self.make_request("campaigns.supported_languages.update", {"campaign_id": self.campaign.id})
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "You are Missing a Required Input: Supported Languages")
+        self.assertEqual(response["error"], MISSING_REQUIRED_FIELD_ERROR_MSG.format("Supported Languages"))
         
     def test_update_campaign_supported_languages_without_campaign_id(self):
         Console.header("Testing update supported languages")
         response = self.make_request("campaigns.supported_languages.update", {"supported_languages": {"en": True, "fr": False}})
         self.assertEqual(response["success"], False)
-        self.assertEqual(response["error"], "You are Missing a Required Input: Campaign Id")
+        self.assertEqual(response["error"], MISSING_REQUIRED_FIELD_ERROR_MSG.format("Campaign Id"))
+        

--- a/src/api/tests/integration/test_supported_languages.py
+++ b/src/api/tests/integration/test_supported_languages.py
@@ -1,13 +1,16 @@
 """
 The following is a test suite for the supported languages endpoints
 """
+import json
 from datetime import datetime
 from django.test import TestCase, Client
 from unittest.mock import patch
 
 from _main_.utils.constants import INVALID_LANGUAGE_CODE_ERR_MSG
-from api.tests.common import signinAs, createUsers, make_supported_language, makeCommunity
-from _main_.utils.utils import Console
+from api.tests.common import create_supported_language, make_campaign, signinAs, createUsers, make_supported_language, \
+    makeCommunity
+from _main_.utils.utils import Console, load_json
+
 
 class SuppportedLanguagesTest(TestCase):
     @classmethod
@@ -23,19 +26,29 @@ class SuppportedLanguagesTest(TestCase):
         self.test_lang_name = "French"
         self.endpoint = "/api/supported_languages"
 
-        self.info_path = "info"
-        self.create_path = "create"
-        self.list_path = "list"
-        self.disable_path = "disable"
-        self.enable_path = "enable"
+        self.info_path = "supported_languages.info"
+        self.create_path = "supported_languages.create"
+        self.list_path = "supported_languages.list"
+        self.disable_path = "supported_languages.disable"
+        self.enable_path = "supported_languages.enable"
+        
+        self.langs = {
+                "en-US": "English (US)",
+                "es-ES": "Spanish (Spain)",
+                "pt-BR": "Portuguese (Brazil)",
+                "fr-FR": "French (France)",
+        }
+        for code, name in self.langs.items():
+            create_supported_language(code=code, name=name)
+            
+        self.campaign = make_campaign()
 
     @classmethod
     def tearDownClass(cls):
-        # Perform any clean-up after running the test case class
         pass
 
     def make_request(self, _path, data=None):
-        return self.client.post(path=f"/api/supported_languages.{_path}", data=data, format='multipart').toDict()
+        return self.client.post(path=f"/api/{_path}", data=data, format='multipart').toDict()
 
     @patch('api.services.supported_language.translate_all_models_into_target_language.apply_async')
     def test_supported_languages_create_as_super_admin(self,mock_apply_async):
@@ -114,3 +127,59 @@ class SuppportedLanguagesTest(TestCase):
 
         self.assertEqual(response["success"], True)
         self.assertTrue(len(response["data"]) > 0)
+        
+        
+    def test_list_campaign_supported_languages_with_UUID(self):
+        Console.header("Testing fetch all supported languages")
+        response = self.make_request("campaigns.supported_languages.list", {"campaign_id": self.campaign.id})
+
+        self.assertEqual(response["success"], True)
+        self.assertTrue(len(response["data"]) > 0)
+        
+        
+    def test_list_campaign_supported_languages_with_invalid_UUID(self):
+        Console.header("Testing fetch all supported languages")
+        response = self.make_request("campaigns.supported_languages.list", {"campaign_id": "invalid"})
+
+        self.assertEqual(response["success"], False)
+        self.assertEqual(response["error"], 'Campaign with id does not exist')
+        
+    def test_list_campaign_supported_languages_without_UUID(self):
+        Console.header("Testing fetch all supported languages")
+        response = self.make_request("campaigns.supported_languages.list")
+
+        self.assertEqual(response["success"], False)
+        self.assertEqual(response["error"], "You are Missing a Required Input: Campaign Id")
+        
+    def test_list_campaign_supported_languages_with_slug(self):
+        Console.header("Testing fetch all supported languages")
+        response = self.make_request("campaigns.supported_languages.list", {"campaign_id": self.campaign.slug})
+
+        self.assertEqual(response["success"], True)
+        self.assertTrue(len(response["data"]) > 0)
+        
+    def test_list_campaign_supported_languages_with_invalid_slug(self):
+        Console.header("Testing fetch all supported languages")
+        response = self.make_request("campaigns.supported_languages.list", {"campaign_id": "invalid"})
+
+        self.assertEqual(response["success"], False)
+        self.assertEqual(response["error"], "Campaign with id does not exist")
+        
+    def test_update_campaign_supported_languages_with_correct_data(self):
+        Console.header("Testing update supported languages")
+        language_data = json.dumps({"en-US": True, "es-ES": True})
+        response = self.make_request("campaigns.supported_languages.update", {"campaign_id": self.campaign.id, "supported_languages": language_data})
+        self.assertEqual(response["success"], True)
+        self.assertTrue(len(response["data"]) > 0)
+        
+    def test_update_campaign_supported_languages_without_data(self):
+        Console.header("Testing update supported languages")
+        response = self.make_request("campaigns.supported_languages.update", {"campaign_id": self.campaign.id})
+        self.assertEqual(response["success"], False)
+        self.assertEqual(response["error"], "You are Missing a Required Input: Supported Languages")
+        
+    def test_update_campaign_supported_languages_without_campaign_id(self):
+        Console.header("Testing update supported languages")
+        response = self.make_request("campaigns.supported_languages.update", {"supported_languages": {"en": True, "fr": False}})
+        self.assertEqual(response["success"], False)
+        self.assertEqual(response["error"], "You are Missing a Required Input: Campaign Id")


### PR DESCRIPTION
####  Summary / Highlights
This PR enhances the campaign-supported language lookup functionality by allowing queries using either the campaign ID or the campaign slug. This improvement ensures that the campaign frontend can retrieve the list of supported languages using the campaign slug, which is the available identifier

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)
run `make test`
#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [x] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
