### PR TITLE
✨ Fix Testimonial Auto-Share Sequence During Creation

### DIFF
--- a/src/api/store/testimonial.py
+++ b/src/api/store/testimonial.py
@@ -197,11 +197,6 @@ class TestimonialStore:
         user = UserProfile.objects.filter(email=user_email).first()
         if user:
           new_testimonial.user = user
-          
-      if is_published:
-          new_testimonial.published_at = parse_datetime_to_aware()
-          add_auto_shared_communities_to_testimonial(new_testimonial)
-
 
       if action:
         testimonial_action = Action.objects.get(id=action)
@@ -240,6 +235,11 @@ class TestimonialStore:
       if tags_to_set:
         new_testimonial.tags.set(tags_to_set)
 
+      new_testimonial.save()
+      
+      if is_published:
+          new_testimonial.published_at = parse_datetime_to_aware()
+          add_auto_shared_communities_to_testimonial(new_testimonial)
       new_testimonial.save()
       
       if audience:

--- a/src/api/store/testimonial.py
+++ b/src/api/store/testimonial.py
@@ -29,12 +29,11 @@ def get_auto_shared_with_list(testimonial):
         3. The auto-share settings contain tags that match the tags of the testimonial.
         The function collects these matching communities and returns a list of them. This list will be used to share the testimonial with those communities.
     """
-    if not testimonial:
+    if not testimonial or not testimonial.community:
+        print("No testimonial or community")
         return []
     
     testimonial_community = testimonial.community 
-    if not testimonial_community:
-        return []
     
     community_zip_codes = set(testimonial_community.locations.values_list('zipcode', flat=True))
     communities_list = set()

--- a/src/api/tests/common.py
+++ b/src/api/tests/common.py
@@ -24,6 +24,7 @@ from database.models import (
     Location, Media,
     Menu, Message,
     RealEstateUnit,
+    Tag,
     Team,
     Testimonial,
     TestimonialAutoShareSettings, UserActionRel,
@@ -496,5 +497,12 @@ def make_section(**kwargs):
         "media": kwargs.get("media"),
     })
     return section
+
+
+def make_tag(**kwargs):
+    return Tag.objects.create(**{
+        **kwargs,
+        "name": kwargs.get("name") or f"New Tag-{datetime.now().timestamp()}",
+    })
     
     

--- a/src/api/tests/unit/utils/test_shareable_testimonial.py
+++ b/src/api/tests/unit/utils/test_shareable_testimonial.py
@@ -14,7 +14,7 @@ class TestGetAutoSharedWithList(TestCase):
         self.c3 = makeCommunity(name="Community - test 3",)
         self.c4 = makeCommunity(name="Community - test 4", )
 
-        self.testimonial = makeTestimonial()
+        self.testimonial = makeTestimonial(title="SHareable Testimonial")
 
 
         self.tag1 = make_tag(name="Solar")
@@ -26,11 +26,12 @@ class TestGetAutoSharedWithList(TestCase):
 
 
     def test_get_auto_shared_with_list_no_community(self):
-        result = get_auto_shared_with_list(self.testimonial)
+        testimonial = makeTestimonial(title="SHareable Testimonial 2223")
+        result = get_auto_shared_with_list(testimonial)
         self.assertEqual(result, [])
 
     def test_get_auto_shared_with_list_no_auto_share_settings(self):
-        self.testimonial.community = self.c1
+        self.testimonial.community = makeCommunity(name="Community - test Within")
         result = get_auto_shared_with_list(self.testimonial)
         self.assertEqual(result.first(), None)
 
@@ -43,7 +44,7 @@ class TestGetAutoSharedWithList(TestCase):
             share_from_location_value='MA'
         )
         result = get_auto_shared_with_list(self.testimonial)
-        self.assertEqual(result.first().name, self.c3.name)
+        self.assertIn(self.c3, list(result))
 
     def test_get_auto_shared_with_list_tags(self):
         self.testimonial.community = self.c1
@@ -54,7 +55,7 @@ class TestGetAutoSharedWithList(TestCase):
         )
         auto_share_settings.excluded_tags.add(self.tag1)
         result = get_auto_shared_with_list(self.testimonial)
-        self.assertEqual(result.first().name, self.c4.name)
+        self.assertIn(self.c4, list(result))
 
     def test_get_auto_shared_with_list_communities(self):
         self.testimonial.community = self.c1
@@ -64,4 +65,4 @@ class TestGetAutoSharedWithList(TestCase):
         )
         auto_share_settings.share_from_communities.set([self.c1])
         result = get_auto_shared_with_list(self.testimonial)
-        self.assertEqual(result.first().name, self.c2.name)
+        self.assertIn(self.c2, list(result))

--- a/src/api/tests/unit/utils/test_shareable_testimonial.py
+++ b/src/api/tests/unit/utils/test_shareable_testimonial.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+from api.store.testimonial import get_auto_shared_with_list
+from api.tests.common import make_tag, makeCommunity, makeLocation, makeTestimonial
+from database.models import TestimonialAutoShareSettings, LocationType
+
+class TestGetAutoSharedWithList(TestCase):
+
+    def setUp(self):
+        loc1 = makeLocation(state="MA", zipcode="02112", city="Boston")
+        loc4 = makeLocation(state="NY", zipcode="02115", city="City")
+        
+        self.c1 = makeCommunity(name="Community - test 1", locations=[loc1.id] )
+        self.c2 = makeCommunity(name="Community - test 2",locations=[loc4.id])
+        self.c3 = makeCommunity(name="Community - test 3",)
+        self.c4 = makeCommunity(name="Community - test 4", )
+
+        self.testimonial = makeTestimonial()
+
+
+        self.tag1 = make_tag(name="Solar")
+        self.tag2 = make_tag(name="Waste")
+        
+    def test_get_auto_shared_with_list_no_testimonial(self):
+        result = get_auto_shared_with_list(None)
+        self.assertEqual(result, [])
+
+
+    def test_get_auto_shared_with_list_no_community(self):
+        result = get_auto_shared_with_list(self.testimonial)
+        self.assertEqual(result, [])
+
+    def test_get_auto_shared_with_list_no_auto_share_settings(self):
+        self.testimonial.community = self.c1
+        result = get_auto_shared_with_list(self.testimonial)
+        self.assertEqual(result.first(), None)
+
+    def test_get_auto_shared_with_list_geographical_range(self):
+        self.testimonial.community = self.c1
+        self.testimonial.save()
+        TestimonialAutoShareSettings.objects.create(
+            community=self.c3,
+            share_from_location_type=LocationType.STATE.value[0],
+            share_from_location_value='MA'
+        )
+        result = get_auto_shared_with_list(self.testimonial)
+        self.assertEqual(result.first().name, self.c3.name)
+
+    def test_get_auto_shared_with_list_tags(self):
+        self.testimonial.community = self.c1
+        self.testimonial.tags.add(self.tag1)
+        self.testimonial.save()
+        auto_share_settings = TestimonialAutoShareSettings.objects.create(
+            community=self.c4,
+        )
+        auto_share_settings.excluded_tags.add(self.tag1)
+        result = get_auto_shared_with_list(self.testimonial)
+        self.assertEqual(result.first().name, self.c4.name)
+
+    def test_get_auto_shared_with_list_communities(self):
+        self.testimonial.community = self.c1
+        self.testimonial.save()
+        auto_share_settings = TestimonialAutoShareSettings.objects.create(
+            community=self.c2,
+        )
+        auto_share_settings.share_from_communities.set([self.c1])
+        result = get_auto_shared_with_list(self.testimonial)
+        self.assertEqual(result.first().name, self.c2.name)


### PR DESCRIPTION
####  Summary / Highlights
This PR addresses an issue where testimonials were being shared with communities prematurely during their creation process. The function used to fetch communities for auto-sharing was called before assigning the community to the testimonial.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
