### PR TITLE
Fix: Users List Filter in Admin Portal

### DIFF
--- a/src/api/tests/unit/utils/test_filter_functions.py
+++ b/src/api/tests/unit/utils/test_filter_functions.py
@@ -3,8 +3,9 @@ import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 from _main_.utils.utils import Console
+from api.tests.common import makeAdminGroup, makeCommunity, makeMembership, makeUser
 from api.utils import filter_functions
-from database.models import Role
+from database.models import Role, UserProfile
 from django.db import transaction
 from django.test.testcases import TestCase
 from database.models import Role, CommunityMember, CommunityAdminGroup
@@ -14,6 +15,19 @@ class FiltersFunctionTests(TestCase):
 	
 	def setUp(self):
 		Console.header("UNIT TEST:(FiltersFunctionTests)")
+		self.u1 = makeUser(email="alpha+1@gmail.com", full_name="Alpha User 1")
+		self.u2 = makeUser(email="beta+2@gmail.com", full_name="Beta User 2")
+		self.u3 = makeUser(email="gamma+3@gmail.com", full_name="Gamma User 3")
+		self.u4 = makeUser(email="delta+4@gmail.com", full_name="Delta User 4")
+		self.su = makeUser(email="su@gmail.com,", full_name="Super User", is_super_admin=True)
+		self.c1 = makeCommunity(name="cAlpha")
+		self.c2 = makeCommunity(name="cBeta")
+
+		self.m1 = makeMembership(user=self.u1, community=self.c1)
+		self.m2 = makeMembership(user=self.u2, community=self.c1)
+
+		self.m3 = makeMembership(user=self.u1, community=self.c2)
+		self.agm = makeAdminGroup(community=self.c1, members=[self.u4], name="TEST AGM")
 
 	@classmethod
 	def tearDownClass(self):
@@ -169,12 +183,10 @@ class FiltersFunctionTests(TestCase):
 	
 	@patch('api.utils.filter_functions.get_sort_params')
 	def test_sort_items_returns_sorted_queryset_when_queryset_is_not_list(self, mock_get_sort_params):
-		# Prepare
 		mock_queryset = MagicMock()
 		mock_get_sort_params.return_value = 'sort_param'
 		params = {'direction': 'asc'}
 		
-		# Act
 		result = filter_functions.sort_items(mock_queryset, params)
 	
 		self.assertEqual(result, mock_queryset.order_by.return_value)
@@ -183,61 +195,94 @@ class FiltersFunctionTests(TestCase):
 	
 	@patch('api.utils.filter_functions.get_sort_params')
 	def test_sort_items_returns_queryset_when_exception_is_raised(self, mock_get_sort_params):
-		# Prepare
 		mock_queryset = MagicMock()
 		mock_queryset.order_by.side_effect = Exception('error')
 		params = {'direction': 'asc'}
 		
-		# Act
 		result = filter_functions.sort_items(mock_queryset, params)
 		
-		# Assert
 		self.assertEqual(result, mock_queryset)
 		mock_get_sort_params.assert_called_once_with(params)
 
-	# ------------------------------------------
 
-	@patch('api.utils.filter_functions.CommunityMember')
-	@patch('api.utils.filter_functions.CommunityAdminGroup')
-	def test_get_users_filter_params_with_community_admin(self, mock_community_admin_group, mock_community_member):
-		params = {'membership': ['Community Admin'], 'community': ['test_community']}
-		mock_community_admin_group.objects.filter.return_value.values_list.return_value.distinct.return_value = [1, 2, 3]
-		result = filter_functions.get_users_filter_params(params)
-		expected_query = [Q(id__in=[1, 2, 3])]
-		self.assertEqual(result, expected_query)
-
-	@patch('api.utils.filter_functions.CommunityMember')
-	@patch('api.utils.filter_functions.CommunityAdminGroup')
-	def test_get_users_filter_params_with_community(self, mock_community_admin_group, mock_community_member):
-		params = {'community': ['test_community']}
-		mock_community_member.objects.filter.return_value.values_list.return_value.distinct.return_value = [1, 2, 3]
-		result = filter_functions.get_users_filter_params(params)
-		expected_query = [Q(id__in=[1, 2, 3])]
-		self.assertEqual(result, expected_query)
-
-	@patch('api.utils.filter_functions.CommunityMember')
-	@patch('api.utils.filter_functions.CommunityAdminGroup')
-	def test_get_users_filter_params_with_roles(self, mock_community_admin_group, mock_community_member):
-		params = {'membership': ['Community Admin',]}
+# --------------------------get_users_filter_params----------------------
+	def test_get_users_filter_params_with_search(self):
+		params = {'search_text': 'Beta'}
 		result = filter_functions.get_users_filter_params(params)
 
-		expected_query = [
-			Q(is_community_admin=True),
-		]
-		self.assertEqual(result, expected_query)
+		self.assertIsInstance(result, list)
+		users = UserProfile.objects.filter(*result)
+		self.assertTrue(users.exists())
+		self.assertIn(self.u2, users)
+		self.assertNotIn(self.u3, users)
 
-
-	@patch('api.utils.filter_functions.CommunityMember')
-	@patch('api.utils.filter_functions.CommunityAdminGroup')
-	def test_get_users_filter_params_with_roles(self, mock_community_admin_group, mock_community_member):
-		params = {'membership': ['Super Admin',]}
+	def test_get_users_filter_params_with_community(self):
+		params = {'community': [self.c1.id]}
 		result = filter_functions.get_users_filter_params(params)
 
-		expected_query = [
-			Q(is_super_admin=True),
-		]
-		self.assertEqual(result, expected_query)
 
+		self.assertIsInstance(result, list)
+		users = UserProfile.objects.filter(*result)
+		
+		self.assertTrue(users.exists())
+		self.assertIn(self.u2, users)
+		self.assertNotIn(self.u3, users)
+		self.assertIn(self.u1, users)
+
+	def test_get_users_filter_params_with_community_and_cadmin_membership(self):
+		params = {'community': [self.c1.id], 'membership': ["Community Admin"]}
+		result = filter_functions.get_users_filter_params(params)
+
+		self.assertIsInstance(result, list)
+
+		users = UserProfile.objects.filter(*result)
+
+		self.assertTrue(users.exists())
+		self.assertNotIn(self.u2, users)
+		self.assertNotIn(self.u1, users)
+		self.assertNotIn(self.u3, users)
+		self.assertIn(self.u4, users)
+
+
+	def test_get_users_filter_params_with_community_and_membership(self):
+		params = {'community': [self.c1.id], 'membership': ["Member"]}
+		result = filter_functions.get_users_filter_params(params)
+
+		self.assertIsInstance(result, list)
+
+		users = UserProfile.objects.filter(*result)
+
+		self.assertTrue(users.exists())
+		self.assertIn(self.u2, users)
+		self.assertIn(self.u1, users)
+		self.assertNotIn(self.u3, users)
+
+	
+	def test_get_users_filter_params_with_membership_normal(self):
+		params = {'membership': ["Member"]}
+		result = filter_functions.get_users_filter_params(params)
+
+		self.assertIsInstance(result, list)
+
+		users = UserProfile.objects.filter(*result)
+		self.assertTrue(users.exists())
+		self.assertIn(self.u2, users)
+		self.assertIn(self.u1, users)
+		self.assertIn(self.u3, users)
+
+	def test_get_users_filter_params_with_membership_su(self):
+		params = params = {'membership': ["Super Admin"]}
+		result = filter_functions.get_users_filter_params(params)
+
+		self.assertIsInstance(result, list)
+
+		users = UserProfile.objects.filter(*result)
+		self.assertTrue(users.exists())
+		self.assertNotIn(self.u2, users)
+		self.assertNotIn(self.u1, users)
+		self.assertNotIn(self.u3, users)
+		self.assertIn(self.su, users)
+		
 
 
 

--- a/src/api/utils/filter_functions.py
+++ b/src/api/utils/filter_functions.py
@@ -323,21 +323,26 @@ def get_users_filter_params(params):
         query.append(search)
 
       communities = params.get("community", None)
+      
       if communities and is_community_admin:
-        if isinstance(communities[0], int):
+        if isinstance(communities, list) and isinstance(communities[0], int):
             users = CommunityAdminGroup.objects.filter(
                 Q(community__id__in=communities)
             ).values_list('members__id', flat=True).distinct()
+
         else:
           users = CommunityAdminGroup.objects.filter(
                 Q(community__name__in=communities)
             ).values_list('members__id', flat=True).distinct()
 
         query.append(Q(id__in=users))
+
         return query
+      
 
       if communities:
-        if isinstance(communities[0], int):
+
+        if isinstance(communities, list) and isinstance(communities[0], int):
             users = CommunityMember.objects.filter(
                 Q(community__id__in=communities)
             ).values_list('user__id', flat=True).distinct()

--- a/src/api/utils/filter_functions.py
+++ b/src/api/utils/filter_functions.py
@@ -324,7 +324,15 @@ def get_users_filter_params(params):
 
       communities = params.get("community", None)
       if communities and is_community_admin:
-        users = CommunityAdminGroup.objects.filter(Q(community__name__in=communities)| Q(community__id__in=communities), members__is_community_admin=True).values_list('members', flat=True).distinct()
+        if isinstance(communities[0], int):
+            users = CommunityAdminGroup.objects.filter(
+                Q(community__id__in=communities)
+            ).values_list('members__id', flat=True).distinct()
+        else:
+          users = CommunityAdminGroup.objects.filter(
+                Q(community__name__in=communities)
+            ).values_list('members__id', flat=True).distinct()
+
         query.append(Q(id__in=users))
         return query
 


### PR DESCRIPTION
####  Summary / Highlights
This pull request fixes the filter functionality of the users list on the admin portal, which was broken due to the joint query in the get_users_filter_params function. The issue arose from attempting to filter users by both community name and community ID within the same query. This PR resolves the issue by splitting the filters into two separate checks: one for community name and one for community ID.

### Works with [Admin PR](https://github.com/massenergize/frontend-admin/pull/1270)

#### Details (Give details about what this PR accomplishes, include any screenshots, etc)

#### Testing Steps (Provide details on how your changes can be tested)
run `make test`
#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
